### PR TITLE
Update registry to point it at the right namespace

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -39,8 +39,8 @@ if [ $? -eq 0 ]; then
   if [ $? -eq 0 ]; then
     echo 'CICO: build OK'
     docker build -t almighty-ui-deploy -f Dockerfile.deploy . && \
-    docker tag almighty-ui-deploy registry.ci.centos.org:5000/almighty/almighty-ui:latest && \
-    docker push registry.ci.centos.org:5000/almighty/almighty-ui:latest
+    docker tag almighty-ui-deploy registry.ci.centos.org:5000/fabric8io/fabric8-ui:latest && \
+    docker push registry.ci.centos.org:5000/fabric8io/fabric8-ui:latest
     if [ $? -eq 0 ]; then
       echo 'CICO: image pushed, ready to update deployed app'
       exit 0


### PR DESCRIPTION
This udpates the registry in the cico_build_deploy.sh script so that we push to the right namespace/image:tag to ensure we don't overwrite the almighty stuff