### PR TITLE
Create new space in backend through SpaceService.

### DIFF
--- a/src/app/profile/spaces/space.service.spec.ts
+++ b/src/app/profile/spaces/space.service.spec.ts
@@ -88,4 +88,20 @@ describe('Service: SpaceService', () => {
     });
   }));
 
+  it('Add new space', async(() => {
+    mockService.connections.subscribe((connection: any) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: JSON.stringify({data: responseData[0]}),
+          status: 201
+        })
+      ));
+    });
+
+    spaceService.create(responseData[0])
+      .then(data => {
+        expect(data).toEqual(expectedResponse[0]);
+      });
+  }));
+
 });

--- a/src/app/profile/spaces/space.service.ts
+++ b/src/app/profile/spaces/space.service.ts
@@ -70,6 +70,22 @@ export class SpaceService {
       .catch(this.handleError);
   }
 
+  create(space: Space): Promise<Space> {
+    let url = this.spacesUrl;
+    let payload = JSON.stringify({data: space});
+    return this.http
+      .post(url, payload, {headers: this.headers})
+      .toPromise()
+      .then(response => {
+        let newSpace: Space = response.json().data as Space;
+        // Add the newly created space at the top of the spaces list.
+        this.spaces.splice(0, 0, newSpace);
+        // Rebuild the map after updating the list
+        this.buildSpaceIndexMap();
+        return newSpace;
+      }).catch(this.handleError);
+  }
+
   // Adds or updates the client-local list of spaces,
   // with spaces retrieved from the server, usually as a page in a paginated collection.
   // If a space already exists in the client-local collection,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature - implements functionality to create spaces at the backend.

* **What is the current behavior?** (You can also link to an open issue here)

No functionality to POST a space to create one, as described in #67 

* **What is the new behavior (if this is a feature change)?**

SpaceService now has a method that can be invoked to create spaces in the backend.

