### PR TITLE
missing space wizard with correct open close behavior

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,8 @@ import { PublicModule } from './public/public.module';
 
 // Shared Components
 import { SpaceDialogModule } from './space-dialog/space-dialog.module';
+import { SpaceWizardModule } from './space-wizard/space-wizard.module';
+
 import { DeleteAccountDialogModule } from './delete-account-dialog/delete-account-dialog.module';
 
 // Login
@@ -77,6 +79,7 @@ export type StoreType = {
     }),
     PublicModule,
     SpaceDialogModule,
+    SpaceWizardModule,
     // AppRoutingModule must appear last
     AppRoutingModule
   ],

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -94,7 +94,7 @@
             <!-- TODO: This should pop up the new space dialog -->
             <a>
               <span class="nav-item-icon"></span>
-              <span class="nav-item-text">
+              <span class="nav-item-text" (click)="spaceWizard.open()" >
                 New space
               </span>
             </a>
@@ -155,3 +155,8 @@
     </ul>
   </div>
 </nav>
+<modal #spaceWizard class="chromeless-modal"  >
+  <modal-content class="chromeless-modal-content" >
+      <space-wizard [host]="spaceWizard" ></space-wizard>
+  </modal-content>
+</modal>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -62,8 +62,8 @@
   </div>
 </div>
 <!-- Create Space modal -->
-<modal #createSpace class="chromeless-modal"  >
+<modal #createSpace class="chromeless-modal" >
   <modal-content class="chromeless-modal-content" >
-      <space-wizard></space-wizard>
+      <space-wizard [host]="createSpace" ></space-wizard>
   </modal-content>
 </modal>

--- a/src/app/space-wizard/space-wizard.component.ts
+++ b/src/app/space-wizard/space-wizard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { Router } from '@angular/router';
 import { DummyService } from '../dummy/dummy.service';
 import { SpaceConfigurator, IWizardSteps, Wizard } from './wizard';
@@ -6,6 +6,16 @@ import { Space, SpaceAttributes } from '../models/space';
 import { ProcessTemplate } from '../models/process-template';
 import { Broadcaster } from '../shared/broadcaster.service';
 import { SpaceService } from "../profile/spaces/space.service";
+
+interface IModal
+{
+  open();
+  close();
+  onOpen();
+  onClose();
+  closeOnEscape:boolean
+  closeOnOutsideClick:boolean
+}
 
 @Component({
   host: {
@@ -22,6 +32,7 @@ export class SpaceWizardComponent implements OnInit {
   configurator: SpaceConfigurator;
   wizard: Wizard = new Wizard();
   wizardSteps: IWizardSteps;
+  @Input() host:IModal;
 
   constructor(
     private router: Router,
@@ -39,6 +50,8 @@ export class SpaceWizardComponent implements OnInit {
       stack: { index: 3 },
       pipeline: { index: 4 },
     };
+    this.host.closeOnEscape=true;
+    this.host.closeOnOutsideClick=false;
   }
 
   reset()
@@ -85,7 +98,10 @@ export class SpaceWizardComponent implements OnInit {
   }
 
   cancel() {
-    this.router.navigate(['/home']);
+    if(this.host)
+    {
+      this.host.close()
+    }
   }
 
 }

--- a/src/app/space-wizard/space-wizard.module.ts
+++ b/src/app/space-wizard/space-wizard.module.ts
@@ -1,15 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ModalModule } from 'ng2-modal';
-import { SpaceDialogModule } from '../space-dialog/space-dialog.module';
-
 import { SpaceWizardComponent } from './space-wizard.component';
 
 @NgModule({
-  imports: [CommonModule, ModalModule, FormsModule, SpaceDialogModule],
+  imports: [CommonModule, FormsModule ],
   declarations: [SpaceWizardComponent],
-  exports: [SpaceWizardComponent, ModalModule]
+  exports: [SpaceWizardComponent]
 })
 export class SpaceWizardModule {
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
-adds missing space wizard to drop down context menu
-correct dialog open close behavior :
      - closes on escape key
      - closes on cancel button
      - does NOT close when clicking outside the modal

* **What is the current behavior?** (You can also link to an open issue here)
-missing dialog and incorrect close behavior



* **What is the new behavior (if this is a feature change)?**
- adds missing space wizard dialog from context menu


* **Other information**:
