### PR TITLE
Get a single space from backend through SpaceService.

### DIFF
--- a/src/app/profile/spaces/space.service.spec.ts
+++ b/src/app/profile/spaces/space.service.spec.ts
@@ -104,4 +104,20 @@ describe('Service: SpaceService', () => {
       });
   }));
 
+  it('Get a single space', async(() => {
+    mockService.connections.subscribe((connection: any) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: JSON.stringify({data: responseData[0]}),
+          status: 200
+        })
+      ));
+    });
+
+    spaceService.getSpaceByName(responseData[0].attributes.name)
+      .then(data => {
+        expect(data).toEqual(expectedResponse[0]);
+      });
+  }));
+
 });

--- a/src/app/profile/spaces/space.service.ts
+++ b/src/app/profile/spaces/space.service.ts
@@ -33,6 +33,24 @@ export class SpaceService {
     return this.getSpacesDelegate(url, isAll);
   }
 
+  getSpaceByName(spaceName: string): Promise<Space> {
+    let result = this.spaces.find(space => space.attributes.name === spaceName);
+    if (result == null) {
+      let url = `${this.spacesUrl}/${spaceName}`;
+      return this.http.get(url, { headers: this.headers } )
+        .toPromise()
+        .then((response) => {
+          let space: Space = response.json().data as Space;
+          this.spaces.splice(this.spaces.length, 0, space);
+          this.buildSpaceIndexMap();
+          return space;
+        })
+        .catch (this.handleError);
+    } else {
+      return Promise.resolve(result);
+    }
+  }
+
   getMoreSpaces(): Promise<any> {
     if (this.nextLink) {
       let isAll = false;


### PR DESCRIPTION
This fetches a single Space instance from the REST API,
using a provided name.

Fixes #82

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature to fetch a single space instance through SpaceService. This can eventually be used in the UI for display or editing

* **What is the current behavior?** (You can also link to an open issue here)

SpaceService does not load single space instances.

* **What is the new behavior (if this is a feature change)?**

Callers can invoke `getSpaceByName(spaceName)` to load the required single space instance identified by it's name, from the backend REST API.

* **Other information**:

Depends on almighty/almighty-core/pull/701