### PR TITLE
Update SpaceService to allow editing of spaces

### DIFF
--- a/src/app/models/space.ts
+++ b/src/app/models/space.ts
@@ -5,7 +5,6 @@ import { ProcessTemplate } from './process-template';
 export interface Space {
     name: string;
     path: String;
-    description: String;
     process?: ProcessTemplate;
     privateSpace?: boolean;
     teams: Team[];
@@ -18,6 +17,7 @@ export interface Space {
 
 export class SpaceAttributes {
     name: string;
+    description: string;
     'updated-at': string;
     'created-at': string;
     version: number;

--- a/src/app/profile/spaces/space.service.spec.ts
+++ b/src/app/profile/spaces/space.service.spec.ts
@@ -104,4 +104,20 @@ describe('Service: SpaceService', () => {
       });
   }));
 
+  it('Get a single space', async(() => {
+    mockService.connections.subscribe((connection: any) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: JSON.stringify({data: responseData[0]}),
+          status: 200
+        })
+      ));
+    });
+
+    spaceService.getSpaceByName(responseData[0].attributes.name)
+      .then(data => {
+        expect(data).toEqual(expectedResponse[0]);
+      });
+  }));
+
 });

--- a/src/app/profile/spaces/space.service.spec.ts
+++ b/src/app/profile/spaces/space.service.spec.ts
@@ -56,11 +56,11 @@ describe('Service: SpaceService', () => {
     {
       name: 'TestSpace',
       path: 'testspace',
-      description: 'This is a space for unit test',
       teams: [],
       defaultTeam: null,
       'attributes': {
         'name': 'TestSpace',
+        'description': 'This is a space for unit test',
         'created-at': null,
         'updated-at': null,
         'version': 0
@@ -117,6 +117,25 @@ describe('Service: SpaceService', () => {
     spaceService.getSpaceByName(responseData[0].attributes.name)
       .then(data => {
         expect(data).toEqual(expectedResponse[0]);
+      });
+  }));
+
+  it('Update a space', async(() => {
+    let updatedData: Space = cloneDeep(responseData[0]);
+    updatedData.attributes.description = 'Updated description';
+
+    mockService.connections.subscribe((connection: any) => {
+      connection.mockRespond(new Response(
+        new ResponseOptions({
+          body: JSON.stringify({data: updatedData}),
+          status: 200
+        })
+      ));
+    });
+
+    spaceService.update(updatedData)
+      .then(data => {
+        expect(data).toEqual(updatedData);
       });
   }));
 

--- a/src/app/profile/spaces/space.service.ts
+++ b/src/app/profile/spaces/space.service.ts
@@ -33,6 +33,24 @@ export class SpaceService {
     return this.getSpacesDelegate(url, isAll);
   }
 
+  getSpaceByName(spaceName: string): Promise<Space> {
+    let result = this.spaces.find(space => space.attributes.name === spaceName);
+    if (result == null) {
+      let url = `${this.spacesUrl}/${spaceName}`;
+      return this.http.get(url, { headers: this.headers } )
+        .toPromise()
+        .then((response) => {
+          let space: Space = response.json().data as Space;
+          this.spaces.splice(this.spaces.length, 0, space);
+          this.buildSpaceIndexMap();
+          return space;
+        })
+        .catch (this.handleError);
+    } else {
+      return Promise.resolve(result);
+    }
+  }
+
   getMoreSpaces(): Promise<any> {
     if (this.nextLink) {
       let isAll = false;

--- a/src/app/profile/spaces/space.service.ts
+++ b/src/app/profile/spaces/space.service.ts
@@ -104,6 +104,25 @@ export class SpaceService {
       }).catch(this.handleError);
   }
 
+  update(space: Space): Promise<Space> {
+    let url = `${this.spacesUrl}/${space.attributes.name}`;
+    let payload = JSON.stringify({data: space});
+    return this.http
+      .patch(url, payload, {headers: this.headers})
+      .toPromise()
+      .then(response => {
+        let updatedSpace = response.json().data as Space;
+        // Find the index in the big list
+        let updateIndex = this.spaces.findIndex(item => item.id == updatedSpace.id);
+        if (updateIndex > -1) {
+          // Update space attributes
+          this.spaces[updateIndex].attributes = updatedSpace.attributes;
+        }
+        return updatedSpace;
+      })
+      .catch(this.handleError);
+  }
+
   // Adds or updates the client-local list of spaces,
   // with spaces retrieved from the server, usually as a page in a paginated collection.
   // If a space already exists in the client-local collection,

--- a/src/app/shared/dummy.service.ts
+++ b/src/app/shared/dummy.service.ts
@@ -258,12 +258,12 @@ export class DummyService {
       {
         name: 'Bobo',
         path: '/pmuir/BalloonPopGame',
-        description: 'Microservices architected search engine',
         teams: [],
         defaultTeam: null,
         id: '0',
         attributes: {
           name: 'Bobo',
+          description: 'Microservices architected search engine',
           'created-at': '2017-01-01',
           'updated-at': '2017-01-02',
           version: 1
@@ -275,12 +275,12 @@ export class DummyService {
       {
         name: 'Hysterix',
         path: '/pmuir/BalloonPopGame',
-        description: 'Hystrix is a latency and fault tolerance library designed to isolate points of access to remote systems, services and 3rd party libraries, stop cascading failure and enable resilience in complex distributed systems where failure is inevitable.',
         teams: [],
         defaultTeam: null,
         id: '1',
         attributes: {
           name: 'Hysterix',
+          description: 'Hystrix is a latency and fault tolerance library designed to isolate points of access to remote systems, services and 3rd party libraries, stop cascading failure and enable resilience in complex distributed systems where failure is inevitable.',
           'created-at': '2017-01-01',
           'updated-at': '2017-01-02',
           version: 1
@@ -292,12 +292,12 @@ export class DummyService {
       {
         name: 'fabric8io',
         path: '/pmuir/BalloonPopGame',
-        description: 'Fabric8 is an open source integrated development platform for Kubernetes',
         teams: [],
         defaultTeam: null,
         id: '2',
         attributes: {
           name: 'fabric8io',
+          description: 'Fabric8 is an open source integrated development platform for Kubernetes',
           'created-at': '2017-01-01',
           'updated-at': '2017-01-02',
           version: 1
@@ -309,7 +309,6 @@ export class DummyService {
       {
         name: 'BalloonPopGame',
         path: '/pmuir/BalloonPopGame',
-        description: 'Balloon popping fun for everyone!',
         teams: [
           this.TEAMS.get('balloonpopgame'),
           this.TEAMS.get('balloonpopgame_ux')
@@ -318,6 +317,7 @@ export class DummyService {
         id: '3',
         attributes: {
           name: 'BalloonPopGame',
+          description: 'Balloon popping fun for everyone!',
           'created-at': '2017-01-01',
           'updated-at': '2017-01-02',
           version: 1

--- a/src/app/space-dialog/space-dialog.component.ts
+++ b/src/app/space-dialog/space-dialog.component.ts
@@ -32,7 +32,6 @@ export class SpaceDialogComponent {
     console.log(this.newSpace);
     // TODO: Once we have dynamic routing, fix this
     this.newSpace.path = '/pmuir/BalloonPopGame';
-    this.newSpace.description = this.newSpace.name;
     this.newSpace.attributes = new SpaceAttributes();
     this.newSpace.attributes.name = this.newSpace.name;
     this.newSpace.type = 'spaces';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature. Fixes #91 to allow consumers of SpaceService to perform editing of spaces.

* **What is the current behavior?** (You can also link to an open issue here)

SpaceService does not support updates to space instances.

* **What is the new behavior (if this is a feature change)?**

A new method to support PATCH requests for space instance objects is created under SpaceService.

* **Other information**:

Builds on top of #90