### PR TITLE
Remove beta/alpha routes and add support for parameterized user id

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -36,82 +36,34 @@ export const routes: Routes = [
     path: 'home',
     loadChildren: './home/home.module#HomeModule'
   },
-  {
-    path: 'beta/home',
-    loadChildren: './home/home.module#HomeModule'
-  },
-  {
-    path: 'alpha/home',
-    loadChildren: './home/home.module#HomeModule'
-  },
 
   // Analyze
   {
-    path: 'pmuir/BalloonPopGame',
-    loadChildren: './analyze/analyze.module#AnalyzeModule'
-  },
-  {
-    path: 'beta/pmuir/BalloonPopGame',
-    loadChildren: './analyze/analyze.module#AnalyzeModule'
-  },
-  {
-    path: 'alpha/pmuir/BalloonPopGame',
+    path: ':id/BalloonPopGame',
     loadChildren: './analyze/analyze.module#AnalyzeModule'
   },
 
   // Plan
   {
-    path: 'pmuir/BalloonPopGame/plan',
+    path: ':id/BalloonPopGame/plan',
     loadChildren: './plan/plan.module#PlanModule'
-  },
-  {
-    path: 'beta/pmuir/BalloonPopGame/plan',
-    loadChildren: './plan-alpha/plan.module#PlanModule'
-  },
-  {
-    path: 'alpha/pmuir/BalloonPopGame/plan',
-    loadChildren: './plan-alpha/plan.module#PlanModule'
   },
 
   // Create
   {
-    path: 'pmuir/BalloonPopGame/create',
-    loadChildren: './create/create.module#CreateModule'
-  },
-  {
-    path: 'beta/pmuir/BalloonPopGame/create',
-    loadChildren: './create/create.module#CreateModule'
-  },
-  {
-    path: 'alpha/pmuir/BalloonPopGame/create',
+    path: ':id/BalloonPopGame/create',
     loadChildren: './create/create.module#CreateModule'
   },
 
   // Run
   {
-    path: 'pmuir/BalloonPopGame/run',
-    loadChildren: './run/run.module#RunModule'
-  },
-  {
-    path: 'beta/pmuir/BalloonPopGame/run',
-    loadChildren: './run/run.module#RunModule'
-  },
-  {
-    path: 'alpha/pmuir/BalloonPopGame/run',
+    path: ':id/BalloonPopGame/run',
     loadChildren: './run/run.module#RunModule'
   },
 
   // Space-settings
   {
-    path: 'pmuir/BalloonPopGame/settings',
-    loadChildren: './space-settings/space-settings.module#SpaceSettingsModule'
-  },
-  {
-    path: 'beta/pmuir/BalloonPopGame/settings',
-    loadChildren: './space-settings/space-settings.module#SpaceSettingsModule'
-  },
-  {
-    path: 'alpha/pmuir/BalloonPopGame/settings',
+    path: ':id/BalloonPopGame/settings',
     loadChildren: './space-settings/space-settings.module#SpaceSettingsModule'
   },
 
@@ -120,26 +72,10 @@ export const routes: Routes = [
     path: 'chat',
     loadChildren: './chat/chat.module#ChatModule'
   },
-  {
-    path: 'beta/chat',
-    loadChildren: './chat/chat.module#ChatModule'
-  },
-  {
-    path: 'alpha/chat',
-    loadChildren: './chat/chat.module#ChatModule'
-  },
 
   // Dashboard
   {
     path: 'dashboard',
-    loadChildren: './dashboard/dashboard.module#DashboardModule'
-  },
-  {
-    path: 'beta/dashboard',
-    loadChildren: './dashboard/dashboard.module#DashboardModule'
-  },
-  {
-    path: 'alpha/dashboard',
     loadChildren: './dashboard/dashboard.module#DashboardModule'
   },
 
@@ -148,26 +84,10 @@ export const routes: Routes = [
     path: 'help',
     loadChildren: './help/help.module#HelpModule'
   },
-  {
-    path: 'beta/help',
-    loadChildren: './help/help.module#HelpModule'
-  },
-  {
-    path: 'alpha/help',
-    loadChildren: './help/help.module#HelpModule'
-  },
 
   // Learn
   {
     path: 'learn',
-    loadChildren: './learn/learn.module#LearnModule'
-  },
-  {
-    path: 'beta/learn',
-    loadChildren: './learn/learn.module#LearnModule'
-  },
-  {
-    path: 'alpha/learn',
     loadChildren: './learn/learn.module#LearnModule'
   },
 
@@ -176,40 +96,16 @@ export const routes: Routes = [
     path: 'notifications',
     loadChildren: './notifications/notifications.module#NotificationsModule'
   },
-  {
-    path: 'beta/notifications',
-    loadChildren: './notifications/notifications.module#NotificationsModule'
-  },
-  {
-    path: 'alpha/notifications',
-    loadChildren: './notifications/notifications.module#NotificationsModule'
-  },
 
   // Profile
   {
-    path: 'pmuir',
-    loadChildren: './profile/profile.module#ProfileModule'
-  },
-  {
-    path: 'beta/pmuir',
-    loadChildren: './profile/profile.module#ProfileModule'
-  },
-  {
-    path: 'alpha/pmuir',
+    path: ':id',
     loadChildren: './profile/profile.module#ProfileModule'
   },
 
   // Settings
   {
-    path: 'pmuir/settings',
-    loadChildren: './settings/settings.module#SettingsModule'
-  },
-  {
-    path: 'beta/pmuir/settings',
-    loadChildren: './settings/settings.module#SettingsModule'
-  },
-  {
-    path: 'alpha/pmuir/settings',
+    path: ':id/settings',
     loadChildren: './settings/settings.module#SettingsModule'
   },
 ];

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-inverse navbar-pf" role="navigation" *ngIf="loggedIn">
+<nav class="navbar navbar-inverse navbar-pf" role="navigation" *ngIf="loggedIn && loggedInUser">
   <div class="navbar-header">
     <ul class="nav navbar-nav navbar-right hidden-sm hidden-md hidden-lg ">
       <li *ngIf="!loggedIn">
@@ -17,7 +17,7 @@
         </a>
         <ul class="dropdown-menu view-width-100">
           <li>
-            <a [routerLink]="[urlFeatureToggle + '/pmuir']">
+            <a [routerLink]="[loggedInUser.id]">
               <span class="nav-item-text">Profile</span>
             </a>
           </li>
@@ -28,7 +28,7 @@
           </li>
           <li class="divider"></li>
           <li>
-            <a [routerLink]="[urlFeatureToggle + '/pmuir/settings']">
+            <a [routerLink]="[loggedInUser.id, 'settings']">
               <span class="nav-item-text">Settings</span>
             </a>
           </li>
@@ -58,7 +58,7 @@
         </a>
         <ul class="dropdown-menu">
           <li *ngFor="let m of dummy.contexts">
-            <a [routerLink]="[urlFeatureToggle + m.path]" *ngIf="m.path !== null && m != context.current">
+            <a [routerLink]="[m.path]" *ngIf="m.path !== null && m != context.current">
               <span class="nav-item-icon">
                 <span class="nav-icon {{m.type.icon}}"></span>
               </span>
@@ -72,7 +72,7 @@
             </a>
           </li>
           <li>
-            <a [routerLink]="[urlFeatureToggle + '/pmuir/spaces']">
+            <a [routerLink]="[loggedInUser.id, 'spaces']">
               <span class="nav-item-icon">
               </span>
               <span class="nav-item-text">
@@ -82,7 +82,7 @@
           </li>
           <li class="divider"></li>
           <li>
-            <a [routerLink]="[urlFeatureToggle + '/home']">
+            <a [routerLink]="['home']">
               <span class="nav-item-icon">
               </span>
               <span class="nav-item-text">
@@ -102,7 +102,7 @@
         </ul>
       </li>
       <li *ngFor="let m of context.current.type.menus" [class.active]="m.active" [class.with-no-children]="(m.menus||[]).length===0">
-        <a [routerLink]="[urlFeatureToggle + m.fullPath]">
+        <a [routerLink]="[m.fullPath]">
           <span *ngIf="m.icon" class="nav-item-icon">
             <span  class="nav-icon {{m.icon}}"></span>
           </span>
@@ -110,7 +110,7 @@
         </a>
         <ul class="nav navbar-nav navbar-persistent" *ngIf="m.menus">
           <li *ngFor="let n of m.menus" [class.active]="n.active">
-            <a [routerLink]="[urlFeatureToggle + n.fullPath]">
+            <a [routerLink]="[n.fullPath]">
               <span class="nav-item-text">
                 {{n.name}}
               </span>
@@ -138,14 +138,14 @@
         </a>
         <ul class="dropdown-menu">
           <li>
-            <a [routerLink]="[urlFeatureToggle + '/pmuir']"><span class="nav-item-text">Profile</span> </a>
+            <a [routerLink]="[loggedInUser.id]"><span class="nav-item-text">Profile</span> </a>
           </li>
           <li>
             <a href="https://fabric8.io/guide/getStarted/index.html"><span class="nav-item-text">Help</span></a>
           </li>
           <li class="divider"></li>
           <li>
-            <a [routerLink]="[urlFeatureToggle + '/pmuir/settings']"><span class="nav-item-text">Settings</span></a>
+            <a [routerLink]="[loggedInUser.id, 'settings']"><span class="nav-item-text">Settings</span></a>
           </li>
           <li>
             <a *ngIf="loggedIn" (click)='logout();'><span class="nav-item-text">Sign out</span></a>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The links are no longer hardcoded to a specific username, also the alpha and beta routes that are unused were removed from the routing file.

* **What is the current behavior?** (You can also link to an open issue here)
Routed had hardcoded user name in the user section

* **What is the new behavior (if this is a feature change)?**
Router links can now be created using the user id - the actual id needs to be added later when the auth code is ready.

* **Other information**:
@joshuawilson 
