### PR TITLE
Set path for spaces.

### DIFF
--- a/src/app/profile/spaces/spaces.component.html
+++ b/src/app/profile/spaces/spaces.component.html
@@ -33,7 +33,7 @@
         <table class="spaces table">
           <tr *ngFor="let s of spaces">
             <td>
-              <h2><a [routerLink]="['/pmuir/' + s.path]">{{s.attributes.name}}</a></h2>
+              <h2><a [routerLink]="['/pmuir/' + 'BalloonPopGame']">{{s.attributes.name}}</a></h2>
               <p>{{s.description}}</p>
             </td>
           </tr>


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix. Temporary fix for #86

* **What is the current behavior?** (You can also link to an open issue here)

Space path is set to 'undefined' as this is not available from the backend REST API.

* **What is the new behavior (if this is a feature change)?**

Hardcodes the space path to `BalloonPopGame` until routing incorporates the use of space names.

* **Other information**:
