### PR TITLE
Changes context creation to use route parameters

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -30,6 +30,18 @@ export const routes: Routes = [
     loadChildren: './home/home.module#HomeModule'
   },
 
+  // Profile
+  {
+    path: ':entity',
+    loadChildren: './profile/profile.module#ProfileModule'
+  },
+
+  // Settings
+  {
+    path: ':entity/settings',
+    loadChildren: './settings/settings.module#SettingsModule'
+  },
+
   // Analyze
   {
     path: ':entity/:space',
@@ -60,17 +72,6 @@ export const routes: Routes = [
     loadChildren: './space-settings/space-settings.module#SpaceSettingsModule'
   },
 
-  // Profile
-  {
-    path: ':entity',
-    loadChildren: './profile/profile.module#ProfileModule'
-  },
-
-  // Settings
-  {
-    path: ':entity/settings',
-    loadChildren: './settings/settings.module#SettingsModule'
-  },
 ];
 
 @NgModule({


### PR DESCRIPTION
This is done as an alternative to: https://github.com/fabric8io/fabric8-ui/pull/166 to demonstrate using route parameters instead of parsing the url.  

The order of the routes is important as well or :entity/settings and :entity/balloonpopgame end up at the same route (this fixes that).

@pmuir @joshuawilson 
