### PR TITLE
175 - Watch for logout event to make sure this.loggedIn is set correctly

### DIFF
--- a/src/app/public/public.component.ts
+++ b/src/app/public/public.component.ts
@@ -37,6 +37,11 @@ export class PublicComponent implements OnInit {
     } else {
       this.loggedIn = this.auth.isLoggedIn();
     }
+
+    this.broadcaster.on('logout').subscribe(() => {
+      this.loggedIn = false;
+    });
+
     this.broadcaster.on<User>('currentUserChanged').subscribe(val => {
       if (this.auth.isLoggedIn()) {
         this.profile.initDefaults(val);


### PR DESCRIPTION
Fixes issue 175 [https://github.com/fabric8io/fabric8-ui/issues/175]
Due to the fact that the /public route was already loaded, the ngOnInit function isn't called again.  This ensures that the loggedIn variable is updated based on the external event from the authentication service.