### PR TITLE
angular2-tree-component version fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "angular2-load-children-loader": "0.1.3",
     "angular2-router-loader": "0.3.5",
     "angular2-template-loader": "0.6.2",
-    "angular2-tree-component": "3.0.2",
+    "angular2-tree-component": "2.8.2",
     "assets-webpack-plugin": "3.5.1",
     "autoprefixer": "6.7.5",
     "awesome-typescript-loader": "3.0.8",


### PR DESCRIPTION
Revert angular2-tree-component from 3.0.2 to 2.8.2.