### PR TITLE
feat(spaces): Display a single space on navigating to the route.

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "ng2-bootstrap": "1.3.3",
     "ngx-dropdown": "0.0.22",
     "ngx-fabric8-wit": "6.8.0",
-    "ngx-login-client": "0.4.3",
+    "ngx-login-client": "0.5.1",
     "ngx-modal": "0.0.29",
     "ngx-widgets": "0.9.5",
     "offline-plugin": "4.6.1",

--- a/src/app/analyze/analyze-overview/analyze-overview.component.ts
+++ b/src/app/analyze/analyze-overview/analyze-overview.component.ts
@@ -29,10 +29,7 @@ export class AnalyzeOverviewComponent {
   }
 
   saveDescription() {
-    this.spaceService.update(this.space)
-      .subscribe(updatedSpace => {
-        this.broadcaster.broadcast('save', updatedSpace);
-      });
+    this.spaceService.update(this.space);
   }
 
 }

--- a/src/app/analyze/analyze-overview/analyze-overview.component.ts
+++ b/src/app/analyze/analyze-overview/analyze-overview.component.ts
@@ -1,4 +1,4 @@
-import { Space, Contexts } from 'ngx-fabric8-wit';
+import { Space, Contexts, SpaceService } from 'ngx-fabric8-wit';
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
@@ -18,6 +18,7 @@ export class AnalyzeOverviewComponent {
   constructor(
     private router: Router,
     context: Contexts,
+    private spaceService: SpaceService,
     private broadcaster: Broadcaster
   ) {
     context.current.subscribe(val => this.space = val.space);
@@ -28,7 +29,10 @@ export class AnalyzeOverviewComponent {
   }
 
   saveDescription() {
-    this.broadcaster.broadcast('save', 1);
+    this.spaceService.update(this.space)
+      .subscribe(updatedSpace => {
+        this.broadcaster.broadcast('save', updatedSpace);
+      });
   }
 
 }

--- a/src/app/profile/spaces/spaces.component.html
+++ b/src/app/profile/spaces/spaces.component.html
@@ -33,7 +33,7 @@
         <table class="spaces table">
           <tr *ngFor="let s of spaces">
             <td>
-              <h2><a [routerLink]="['/pmuir/' + s.path]">{{s.attributes.name}}</a></h2>
+              <h2><a [routerLink]="['/pmuir/', s.attributes.name]">{{s.attributes.name}}</a></h2>
               <p>{{s.description}}</p>
             </td>
           </tr>

--- a/src/app/profile/spaces/spaces.component.html
+++ b/src/app/profile/spaces/spaces.component.html
@@ -33,7 +33,7 @@
         <table class="spaces table">
           <tr *ngFor="let s of spaces">
             <td>
-              <h2><a [routerLink]="['/pmuir/', s.attributes.name]">{{s.attributes.name}}</a></h2>
+              <h2><a [routerLink]="['/'+s.relationalData.creator.attributes.username, s.attributes.name]">{{s.attributes.name}}</a></h2>
               <p>{{s.description}}</p>
             </td>
           </tr>

--- a/src/app/shared/context.service.ts
+++ b/src/app/shared/context.service.ts
@@ -221,8 +221,8 @@ export class ContextService implements Contexts {
     return null;
   }
 
-  private loadUser(userName: string): Observable<Entity> {
-    return Observable.of(this.dummy.lookupUser(userName));
+  private loadUser(userName: string): Observable<User> {
+    return this.user.getUserByUsername(userName);
   }
 
   private extractSpace(): string {

--- a/src/app/shared/dummy.service.ts
+++ b/src/app/shared/dummy.service.ts
@@ -103,110 +103,6 @@ export class DummyService {
     ]
   ]);
 
-  readonly SPACES: Map<string, Space> = new Map<string, Space>([
-    [
-      'bobo',
-      {
-        name: 'Bobo',
-        path: '/pmuir/BalloonPopGame',
-        teams: [],
-        defaultTeam: this.TEAMS.get('balloonpopgame'),
-        id: '0',
-        attributes: {
-          name: 'Bobo',
-          description: 'Microservices architected search engine',
-          'created-at': '2017-01-01',
-          'updated-at': '2017-01-02',
-          version: 1
-        },
-        type: 'spaces',
-        links: {self:''},
-        relationships: {
-          areas: {links:{related:''}},
-          iterations: {links:{related:''}}
-        }
-      } as Space
-    ], [
-      'hysterix',
-      {
-        name: 'Hysterix',
-        path: '/pmuir/hysterix',
-        teams: [],
-        defaultTeam: this.TEAMS.get('balloonpopgame'),
-        id: '1',
-        attributes: {
-          name: 'Hysterix',
-          description: 'Hystrix is a latency and fault tolerance library designed to isolate points of access to remote systems, services and 3rd party libraries, stop cascading failure and enable resilience in complex distributed systems where failure is inevitable.',
-          'created-at': '2017-01-01',
-          'updated-at': '2017-01-02',
-          version: 1
-        },
-        type: 'spaces',
-        links: {self:''},
-        relationships: {
-          areas: {links:{related:''}},
-          iterations: {links:{related:''}}
-        }
-      } as Space
-    ], [
-      'fabric8',
-      {
-        name: 'fabric8io',
-        path: '/pmuir/BalloonPopGame',
-        teams: [],
-        defaultTeam: this.TEAMS.get('balloonpopgame'),
-        id: '2',
-        attributes: {
-          name: 'fabric8io',
-          description: 'Fabric8 is an open source integrated development platform for Kubernetes',
-          'created-at': '2017-01-01',
-          'updated-at': '2017-01-02',
-          version: 1
-        },
-        type: 'spaces',
-        links: {self:''},
-        relationships: {
-          areas: {links:{related:''}},
-          iterations: {links:{related:''}}
-        }
-      } as Space
-    ], [
-      'balloonpopgame',
-      {
-        name: 'BalloonPopGame',
-        path: '/pmuir/BalloonPopGame',
-        teams: [
-          this.TEAMS.get('balloonpopgame'),
-          this.TEAMS.get('balloonpopgame_ux')
-        ],
-        defaultTeam: this.TEAMS.get('balloonpopgame'),
-        id: '3',
-        attributes: {
-          name: 'BalloonPopGame',
-          description: 'Balloon popping fun for everyone!',
-          'created-at': '2017-01-01',
-          'updated-at': '2017-01-02',
-          version: 1
-        },
-        type: 'spaces',
-        links: {self:''},
-        relationships: {
-          areas: {links:{related:''}},
-          iterations: {links:{related:''}}
-        },
-        stacks: [
-          {
-            codebase: 'https://github.com/BalloonPopGame/BalloonPopGame',
-            uuid: 'e7815fca5e0946ab8701220fbda22e38'
-          }, {
-            codebase: 'https://github.com/BalloonPopGame/BalloonPopGame-UI',
-            uuid: 'e7815fca5e0946ab8701220fbda22e38'
-          }
-        ]
-      } as Space
-    ]
-  ]);
-
   readonly PROCESS_TEMPLATES: ProcessTemplate[] = [
     { name: 'Agile' },
     { name: 'Scrum' },
@@ -223,7 +119,7 @@ export class DummyService {
     private localStorageService: LocalStorageService,
     private broadcaster: Broadcaster
   ) {
-    this._spaces = this.initDummy('spaces', this.SPACES);
+    this._spaces = [];
     this._recentContexts = [];
     this._users = this.initDummy('users', this.USERS);
     this.broadcaster.on<string>('save')
@@ -284,14 +180,6 @@ export class DummyService {
       }
     }
     return null;
-  }
-
-  lookupSpace(space: string): Space {
-    if (space) {
-      return this.SPACES.get(space.toLowerCase());
-    } else {
-      return null;
-    }
   }
 
   public addUser(add: User) {


### PR DESCRIPTION
Wired up the spaceService to fetch the individual space, based on the user and space name retrieved from ActivatedRoute.

Also wired up spaceService to be used during updates made to a space's description.
Names are also used to display the links, as path is not computed.

Points to consider:

1. This does not use any Resolver to fetch the space and then perform the navigation. A Resolver can be wired up later, to use `SpaceService.getSpaceByName`
2. Paths can be computed or dropped entirely, as space names can be used in the links.