### PR TITLE
fix(build): exclude problematic sourcemaps

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -119,6 +119,11 @@ module.exports = function (options) {
           exclude: [
             // Example helpers.nodeModulePath("fabric8-planner"),
             // Exclude any problematic sourcemaps
+            helpers.nodeModulePath("mydatepicker"),
+            helpers.nodeModulePath("ng2-completer"),
+            helpers.nodeModulePath("angular2-flash-messages"),
+            helpers.nodeModulePath("ngx-dropdown"),
+            helpers.nodeModulePath("ngx-modal")
           ],
           use: ["source-map-loader"],
           enforce: "pre"

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -123,7 +123,8 @@ module.exports = function (options) {
             helpers.nodeModulePath("ng2-completer"),
             helpers.nodeModulePath("angular2-flash-messages"),
             helpers.nodeModulePath("ngx-dropdown"),
-            helpers.nodeModulePath("ngx-modal")
+            helpers.nodeModulePath("ngx-modal"),
+            helpers.nodeModulePath("ng2-dnd")
           ],
           use: ["source-map-loader"],
           enforce: "pre"


### PR DESCRIPTION
excludes sourcemaps for several libraries that
are not configured correctly

