### PR TITLE
feat(spaces): Display list of owned spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "mydatepicker": "1.7.3",
     "ng2-bootstrap": "1.3.3",
     "ngx-dropdown": "0.0.22",
-    "ngx-fabric8-wit": "6.13.0",
+    "ngx-fabric8-wit": "6.14.3",
     "ngx-login-client": "0.6.1",
     "ngx-modal": "0.0.29",
     "ngx-widgets": "0.9.5",

--- a/src/app/profile/spaces/spaces.component.ts
+++ b/src/app/profile/spaces/spaces.component.ts
@@ -29,10 +29,14 @@ export class SpacesComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.spaceService.getSpaces(this.pageSize)
-      .subscribe(spaces => {
-        this._spaces = spaces;
-      });
+    if (this.context && this.context.user) {
+      this.spaceService.getSpacesByUser(this.context.user.attributes.username)
+        .subscribe(spaces => {
+          this._spaces = spaces;
+        });
+    } else {
+      this.logger.error("Failed to retrieve list of spaces owned by user");
+    }
     this.searchTermStream
       .debounceTime(300)
       .distinctUntilChanged()

--- a/src/app/shared/notifications.service.ts
+++ b/src/app/shared/notifications.service.ts
@@ -41,4 +41,8 @@ export class NotificationsService implements Notifications {
     return this.notificationService.getNotifications();
   }
 
+  get recent(): Observable<Notification[]> {
+    return Observable.empty();
+  }
+
 }


### PR DESCRIPTION
This ensures that the list of spaces owned by a user is displayed
under /_spaces instead of the global list of spaces.

Please don't merge as this is depends on couple of other PRs. Relies on https://github.com/fabric8-ui/ngx-fabric8-wit/pull/33 to work. An upgrade to ngx-fabric8-wit is also pending.