### PR TITLE
Env vars

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -5,8 +5,15 @@ ENV LANG=en_US.utf8
 
 USER root
 ADD nginx.conf /etc/nginx/nginx.conf
-USER 997
+
+# Add the templater to run.sh
+RUN sed -i '2s/^/\/template.sh \/usr\/share\/nginx\/html \n/' /run.sh
 
 RUN rm /usr/share/nginx/html/*
 
+ADD template.sh /
+
 COPY dist /usr/share/nginx/html
+
+RUN chown -R 997 /usr/share/nginx/html
+USER 997

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -12,6 +12,7 @@ const commonConfig = require('./webpack.common.js'); // the settings that are co
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 const NamedModulesPlugin = require('webpack/lib/NamedModulesPlugin');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 /**
  * Webpack Constants
@@ -127,6 +128,17 @@ module.exports = function (options) {
     },
 
     plugins: [
+      new CopyWebpackPlugin([
+        {
+          from: 'src/config',
+          to: '_config',
+          transform: function env(content, path) {
+            return content.toString('utf-8').replace(/{{ .Env.([a-zA-Z0-9_-]*) }}/g, function(match, p1, offset, string){
+              return process.env[p1];
+            });
+          }
+        }
+      ]),
       /**
        * Plugin: DefinePlugin
        * Description: Define free variables.

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -10,6 +10,7 @@ const stringify = require('json-stringify');
 /**
  * Webpack Plugins
  */
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const DedupePlugin = require('webpack/lib/optimize/DedupePlugin');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
@@ -113,6 +114,12 @@ module.exports = function (env) {
      * See: http://webpack.github.io/docs/configuration.html#plugins
      */
     plugins: [
+      new CopyWebpackPlugin([
+        {
+          from: 'src/config',
+          to: 'config'
+        }
+      ]),
 
       /**
        * Plugin: @ngtools/webpack

--- a/src/config/oauth.json
+++ b/src/config/oauth.json
@@ -1,0 +1,10 @@
+{
+  "api_server": "{{ .Env.K8S_API_SERVER }}",
+  "oauth": {
+    "oauth_authorize_uri": "{{ .Env.OAUTH_AUTHORIZE_URI }}",
+    "oauth_client_id": "{{ .Env.OAUTH_CLIENT_ID }}",
+    "oauth_issuer": "{{ .Env.OAUTH_ISSUER }}",
+    "oauth_scope": "{{ .Env.OAUTH_SCOPE }}",
+    "logout_uri": "{{ .Env.OAUTH_LOGOUT_URI }}"
+  }
+}

--- a/template.sh
+++ b/template.sh
@@ -1,0 +1,21 @@
+#!bin/bash
+
+OUTDIR="$@/_config"
+INDIR="$@/config"
+mkdir -p ${OUTDIR}
+
+for infile in $INDIR/*; do
+  tmpfile=${infile}.tmp
+  outfile=${OUTDIR}/`basename ${infile}`
+  echo "Templating ${infile} and saving as ${outfile}"
+  sed "s/{{ .Env.\([a-zA-Z0-9_-]*\) }}/\${\1}/" < ${infile} | sed 's/"/\\"/g' > ${tmpfile}
+  eval "echo \"$(cat ${tmpfile})\"" > $outfile
+  rm ${tmpfile}
+  echo ""
+  echo "----------------"
+  cat $outfile
+  echo "----------------"
+  echo ""
+done
+
+rm -rf $INDIR


### PR DESCRIPTION
fix(build): add support for templated env vars

* Uses caddy style templating
* Supports any env var
* When in dev mode, use webpack to var substitution using html webpack plugin
* When running under nginx, use a shell script to substitute variables before starting nginx

Fixes fabric8-ui/fabric8-runtime-console#95