### PR TITLE
fix(version): changes the version number of fabric8-stack-analysis-ui…

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "core-js": "2.4.1",
     "fabric8-planner": "0.17.7",
     "fabric8-runtime-console": "0.4.0",
-    "fabric8-stack-analysis-ui": "0.0.1",
+    "fabric8-stack-analysis-ui": "0.0.2",
     "http-server": "0.9.0",
     "ie-shim": "0.1.0",
     "lodash": "4.17.4",


### PR DESCRIPTION
changes the version number of fabric8-stack-analysis-ui npm package.

How does it affect?

1. Changes the URL to point to the new prod preview API url - stack-analyses
2. Moves all the hardcoded strings to respective constant files
3. Fixes a minor alignment issue in UI
4. Adds the build number in the modal title.
5. Changes for creating a work item.

It doesn't yet show the link of the newly created work item - (Reason: Changes in the URL structure)

