### PR TITLE
Initial codebases page

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "ngx-fabric8-wit": "6.16.2",
     "ngx-login-client": "0.6.11",
     "ngx-modal": "0.0.29",
-    "ngx-widgets": "0.12.5",
+    "ngx-widgets": "0.12.6",
     "offline-plugin": "4.6.1",
     "pluralize": "4.0.0",
     "rxjs": "5.0.1",

--- a/src/app/create/codebases/codebases-create/codebases-create.component.html
+++ b/src/app/create/codebases/codebases-create/codebases-create.component.html
@@ -1,0 +1,26 @@
+<alm-slide-out-panel [panelState]="panelState" (panelStateChange)="togglePanelState($event)">
+  <form class="form-horizontal" role="form">
+    <p class="fields-status-pf">The fields marked with <span class="required-pf">*</span> are required.</p>
+    <div class="form-group">
+      <label for="spacePath" class="col-sm-2 control-label" disabled>Space Path</label>
+      <div class="col-sm-9">
+        <input type="text" class="form-control" id="spacePath" name="spacePath" disabled
+               [ngModel]="context.path">
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="gitHubRepo" class="col-sm-2 control-label required-pf">GitHub Repository</label>
+      <div class="col-sm-9">
+        <input type="text" class="form-control" id="gitHubRepo" name="gitHubRepo"
+               placeholder="git@github.com:almighty/almighty-core.git"
+               [(ngModel)]="gitHubRepo">
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-3">
+        <button type="submit" class="btn btn-primary"
+                (click)="create($event)">Associate Repository</button>
+      </div>
+    </div>
+  </form>
+</alm-slide-out-panel>

--- a/src/app/create/codebases/codebases-create/codebases-create.component.ts
+++ b/src/app/create/codebases/codebases-create/codebases-create.component.ts
@@ -1,0 +1,64 @@
+import { Component, EventEmitter, OnInit, Output, ViewEncapsulation } from '@angular/core';
+
+import { Codebase } from '../services/codebase';
+import { CodebasesService } from '../services/codebases.service';
+import { Logger } from 'ngx-base';
+import { Context, Contexts } from 'ngx-fabric8-wit';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'codebases-create',
+  templateUrl: './codebases-create.component.html',
+  styleUrls: ['./codebases-create.component.scss'],
+  providers: [CodebasesService]
+})
+export class CodebasesCreateComponent implements OnInit {
+  @Output('onCreate') onCreate = new EventEmitter();
+
+  context: Context;
+  gitHubRepo: string;
+  panelState: string = "out";
+
+  constructor(
+      private codebasesService: CodebasesService,
+      private contexts: Contexts,
+      private logger: Logger) {
+    this.contexts.current.subscribe(val => this.context = val);
+  }
+
+  ngOnInit() {
+  }
+
+  create($event: MouseEvent): void {
+    if (this.gitHubRepo === undefined || this.gitHubRepo.trim().length === 0) {
+      return;
+    }
+    let codebase = this.createTransientCodebase();
+    this.codebasesService.create(this.context.space.id, codebase).subscribe(codebase => {
+      this.onCreate.emit(codebase);
+      this.togglePanelState("out");
+    });
+  }
+
+  createTransientCodebase(): Codebase {
+    return {
+      attributes: {
+        type: 'git',
+        url: this.gitHubRepo
+      },
+      type: 'codebases'
+    } as Codebase;
+  }
+
+  togglePanel($event: MouseEvent): void {
+    if (this.panelState === "in") {
+      this.panelState = "out";
+    } else {
+      this.panelState = "in";
+    }
+  }
+
+  togglePanelState($event: any): void {
+    this.panelState = $event;
+  }
+}

--- a/src/app/create/codebases/codebases-create/codebases-create.module.ts
+++ b/src/app/create/codebases/codebases-create/codebases-create.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, Http } from '@angular/http';
+import { SlideOutPanelModule } from 'ngx-widgets';
+
+import { CodebasesCreateComponent } from './codebases-create.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    HttpModule,
+    SlideOutPanelModule
+  ],
+  declarations: [ CodebasesCreateComponent ],
+  exports: [ CodebasesCreateComponent ]
+})
+export class CodebasesCreateModule {
+  constructor(http: Http) {}
+}

--- a/src/app/create/codebases/codebases.component.html
+++ b/src/app/create/codebases/codebases.component.html
@@ -1,5 +1,70 @@
+<toolbar-panel (onAddClick)="create.togglePanel($event)"></toolbar-panel>
+<codebases-create (onCreate)="addCodebase($event)" #create></codebases-create>
 <div id="codebases" class="container content">
-  <!-- can someone please show me how to make this be a relative url for the current component's directory?
-       I really just want to use 'codebases.png', but I've been unable to figure out how to do that -->
-  <img src='/assets/img/mockups/codebases.png' style="width:100%;">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="heading list-group list-view-pf">
+        <div class="list-view-pf-description">
+          <div class="list-group-item-heading">
+            <span>Name</span>
+          </div>
+          <div class="list-group-item-text">
+            <span>Created Date</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <alm-listview
+          [config]="listViewConfig"
+          [items]="codebases"
+          [itemTemplate]="itemTemplate"
+          [itemExpandedTemplate]="itemExpandedTemplate">
+        <template #itemTemplate let-codebase="item" let-index="index">
+          <span class="avatar fa" [ngClass]="{'fa-github': codebase.attributes.type === 'git'}"></span>
+          <div class="list-view-pf-description">
+            <div class="list-group-item-heading">
+              <a href="{{getUrl(codebase)}}" target="_blank">{{getName(codebase)}}</a>
+            </div>
+            <div class="list-group-item-text">
+              {{codebase.attributes.createdAt | date:'medium'}}
+            </div>
+          </div>
+          <!--
+          <div class="list-view-pf-additional-info">
+            <div class="list-view-pf-additional-info-item">
+              {{item.attributes.createdAt | date:'medium'}}
+            </div>
+          </div>
+          -->
+        </template>
+        <template #itemExpandedTemplate let-codebase="item" let-index="index">
+          <div class="row">
+            <div class="col-md-3">
+              <dl class="dl-horizontal">
+                <dt>Commit History</dt>
+              </dl>
+            </div>
+            <div class="col-md-9">
+              <dl class="dl-horizontal">
+                <dt>Git URL</dt>
+                <dd><a href="{{getUrl(codebase)}}" target="_blank">{{getUrl(codebase)}}</a></dd>
+                <dt>Latest Commit SHA1</dt>
+                <dd>9bc99eb964c57200ff163619326b9cfaa82aee8b</dd>
+                <dt>Status</dt>
+                <dd>3 commits ahead of Master</dd>
+                <dd>25 total files changed</dd>
+                <dt>Dependents</dt>
+                <dd>0 Packages / 0 Applications</dd>
+                <dt>License</dt>
+                <dd>None</dd>
+              </dl>
+            </div>
+          </div>
+        </template>
+      </alm-listview>
+    </div>
+  </div>
 </div>

--- a/src/app/create/codebases/codebases.component.scss
+++ b/src/app/create/codebases/codebases.component.scss
@@ -1,1 +1,20 @@
 .content {}
+
+.avatar {
+  font-size: 18px;
+  margin-right: 10px;
+}
+
+.heading {
+  &.list-group {
+    border-top: none;
+    margin-left: 60px;
+    .list-group-item-heading {
+      margin-right: 150px;
+    }
+  }
+}
+
+.list-view-pf-expand {
+  margin-top: 15px;
+}

--- a/src/app/create/codebases/codebases.component.ts
+++ b/src/app/create/codebases/codebases.component.ts
@@ -1,20 +1,95 @@
-import { Component, OnInit } from '@angular/core';
-import { Router }            from '@angular/router';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { Codebase } from './services/codebase';
+import { CodebasesService } from './services/codebases.service';
+import { ListViewConfig } from 'ngx-widgets';
+import { Logger } from 'ngx-base';
+import { Context, Contexts } from 'ngx-fabric8-wit';
 
 @Component({
-  selector: 'alm-codebases',
-  templateUrl: 'codebases.component.html',
-  styleUrls: ['./codebases.component.scss']
+  encapsulation: ViewEncapsulation.None,
+  selector: 'codebases',
+  templateUrl: './codebases.component.html',
+  styleUrls: ['./codebases.component.scss'],
+  providers: [CodebasesService]
 })
 export class CodebasesComponent implements OnInit {
+  codebases: Codebase[];
+  context: Context;
+  listViewConfig: ListViewConfig;
 
   constructor(
-    private router: Router) {
+      private codebasesService: CodebasesService,
+      private contexts: Contexts,
+      private logger: Logger,
+      private router: Router) {
+    this.contexts.current.subscribe(val => this.context = val);
   }
 
   ngOnInit() {
-    
+    if (this.context && this.context.space) {
+      this.codebasesService.getCodebases(this.context.space.id).subscribe(codebases => {
+        this.codebases = codebases;
+
+        // Todo: Temporary associate codebase until empty state config is ready
+        if (this.codebases === undefined || this.codebases.length == 0) {
+          let codebase = this.createTransientCodebase();
+          this.codebasesService.create(this.context.space.id, codebase).subscribe(codebase => {
+            this.codebases = [codebase];
+          });
+        }
+      });
+    } else {
+      this.logger.error("Failed to retrieve codebases");
+    }
+
+    this.listViewConfig = {
+      dblClick: false,
+      dragEnabled: false,
+      //emptyStateConfig: this.emptyStateConfig,
+      multiSelect: false,
+      selectItems: false,
+      //selectionMatchProp: 'name',
+      showSelectBox: false,
+      useExpandingRows: true
+    } as ListViewConfig;
   }
 
+  // Todo: Temporary associate codebase until empty state config is ready
+  createTransientCodebase(): Codebase {
+    return {
+      attributes: {
+        type: 'git',
+        url: 'git@github.com:almighty/almighty-core.git'
+      },
+      type: 'codebases'
+    } as Codebase;
+  }
 
+  getName(codebase: Codebase): string {
+    if (codebase.attributes.type === 'git') {
+      return codebase.attributes.url.replace('.git', '').replace('git@github.com:', '');
+    } else {
+      codebase.attributes.url;
+    }
+  }
+
+  getUrl(codebase: Codebase): string {
+    if (codebase.attributes.type === 'git') {
+      return codebase.attributes.url.replace('.git', '').replace(':', '/').replace('git@', 'https://');
+    } else {
+      codebase.attributes.url;
+    }
+  }
+
+  // Slide-out Panel
+
+  // Todo: Move to own component
+  addCodebase($event: Codebase): void {
+    if (this.codebases === undefined) {
+      this.codebases = [];
+    }
+    this.codebases.push($event);
+  }
 }

--- a/src/app/create/codebases/codebases.module.ts
+++ b/src/app/create/codebases/codebases.module.ts
@@ -1,15 +1,27 @@
-import { NgModule }         from '@angular/core';
-import { CommonModule }     from '@angular/common';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { HttpModule, Http } from '@angular/http';
+import { ListViewModule } from 'ngx-widgets';
 
-import { CodebasesComponent }     from './codebases.component';
+import { CodebasesCreateModule } from './codebases-create/codebases-create.module';
+import { CodebasesComponent } from './codebases.component';
 import { CodebasesRoutingModule } from './codebases-routing.module';
+import { ToolbarPanelModule } from '../../toolbar/toolbar-panel.module';
 
 @NgModule({
-  imports:      [ CommonModule, CodebasesRoutingModule, HttpModule ],
+  imports: [
+    CommonModule,
+    CodebasesCreateModule,
+    CodebasesRoutingModule,
+    FormsModule,
+    HttpModule,
+    ListViewModule,
+    ToolbarPanelModule
+  ],
   declarations: [ CodebasesComponent ],
+  exports: [ CodebasesComponent ]
 })
 export class CodebasesModule {
   constructor(http: Http) {}
-
 }

--- a/src/app/create/codebases/services/codebase.ts
+++ b/src/app/create/codebases/services/codebase.ts
@@ -1,0 +1,42 @@
+export class Codebase {
+    attributes: CodebaseAttributes;
+    id?: string;
+    links?: CodebaseLinks;
+    relationships?: CodebaseRelations;
+    type: string;
+}
+
+export class CodebaseAttributes {
+    createdAt?: string;
+    type?: string;
+    url?: string;
+}
+
+export class CodebaseLinks {
+    edit?: string;
+    meta?: any;
+    related?: string;
+    self?: string;
+}
+
+export class CodebaseRelations {
+    space?: RelationGeneric;
+}
+
+export class RelationGeneric {
+    data?: GenericData;
+    links?: GenericLinks;
+    meta?: any
+}
+
+export class GenericData {
+    id?: string;
+    links?: GenericLinks;
+    type?: string;
+}
+
+export class GenericLinks {
+    meta?: any;
+    related?: string;
+    self?: string;
+}

--- a/src/app/create/codebases/services/codebases.service.ts
+++ b/src/app/create/codebases/services/codebases.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, Inject } from '@angular/core';
+import { Headers, Http } from '@angular/http';
+import { AuthenticationService, UserService } from 'ngx-login-client';
+import { Logger } from 'ngx-base';
+import { Observable } from 'rxjs';
+
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+import { Codebase } from './codebase';
+
+@Injectable()
+export class CodebasesService {
+  private headers = new Headers({ 'Content-Type': 'application/json' });
+  private spacesUrl: string;
+  private nextLink: string = null;
+
+  constructor(
+    private http: Http,
+    private logger: Logger,
+    private auth: AuthenticationService,
+    private userService: UserService,
+    @Inject(WIT_API_URL) apiUrl: string) {
+    if (this.auth.getToken() != null) {
+      this.headers.set('Authorization', 'Bearer ' + this.auth.getToken());
+    }
+    this.spacesUrl = apiUrl + 'spaces';
+  }
+
+  getCodebases(spaceId: string): Observable<Codebase[]> {
+    let url = `${this.spacesUrl}/${spaceId}/codebases`;
+    return this.http.get(url, { headers: this.headers })
+        .map((response) => {
+          return response.json().data as Codebase;
+        })
+        .catch((error) => {
+          return this.handleError(error);
+        });
+  }
+
+  getCodebasesPaged(spaceId: string, pageSize: number = 20): Observable<Codebase[]> {
+    let url = `${this.spacesUrl}/${spaceId}/codebases` + '?page[limit]=' + pageSize;
+    return this.getCodebasesDelegate(url, true);
+  }
+
+  getCodebasesDelegate(url: string, isAll: boolean): Observable<Codebase[]> {
+    return this.http
+      .get(url, { headers: this.headers })
+      .map(response => {
+        // Extract links from JSON API response.
+        // and set the nextLink, if server indicates more resources
+        // in paginated collection through a 'next' link.
+        let links = response.json().links;
+        if (links.hasOwnProperty('next')) {
+          this.nextLink = links.next;
+        } else {
+          this.nextLink = null;
+        }
+        // Extract data from JSON API response, and assert to an array of spaces.
+        let newCodebases: Codebase[] = response.json().data as Codebase[];
+        return newCodebases;
+      })
+      .catch((error) => {
+        return this.handleError(error);
+      });
+  }
+
+  getMoreCodebases(): Observable<Codebase[]> {
+    if (this.nextLink) {
+      return this.getCodebasesDelegate(this.nextLink, false);
+    } else {
+      return Observable.throw('No more codebases found');
+    }
+  }
+
+  create(spaceId: string, codebase: Codebase): Observable<Codebase> {
+    let url = `${this.spacesUrl}/${spaceId}/codebases`;
+    let payload = JSON.stringify({ data: codebase });
+    return this.http
+        .post(url, payload, { headers: this.headers })
+        .map(response => {
+          return response.json().data as Codebase;
+        })
+        .catch((error) => {
+          return this.handleError(error);
+        });
+  }
+
+  update(codebase: Codebase): Observable<Codebase> {
+    let url = `${this.spacesUrl}/${codebase.id}`;
+    let payload = JSON.stringify({ data: codebase });
+    return this.http
+        .patch(url, payload, { headers: this.headers })
+        .map(response => {
+          return response.json().data as Codebase;
+        })
+        .catch((error) => {
+          return this.handleError(error);
+        });
+  }
+
+  private handleError(error: any) {
+    this.logger.error(error);
+    return Observable.throw(error.message || error);
+  }
+}

--- a/src/app/toolbar/toolbar-panel.component.html
+++ b/src/app/toolbar/toolbar-panel.component.html
@@ -1,0 +1,13 @@
+<div class="toolbar-header">
+  <alm-toolbar
+      [config]="toolbarConfig"
+      [viewsTemplate]="addTemplate"
+      (onFilterChange)="filterChange($event)"
+      (onSortChange)="sortChange($event)">
+    <template #add>
+      <div class="with-cursor-pointer" placement="bottom" tooltip="Add A Codebase" (click)="onClick()">
+        <i class="pficon pficon-add-circle-o margin-top-4"></i>
+      </div>
+    </template>
+  </alm-toolbar>
+</div>

--- a/src/app/toolbar/toolbar-panel.component.scss
+++ b/src/app/toolbar/toolbar-panel.component.scss
@@ -1,0 +1,12 @@
+@import '../../assets/stylesheets/base';
+
+.toolbar-header {
+  padding: 0 rem(20);
+  border-bottom: 1px solid $color-pf-black-300;
+}
+
+.toolbar-pf-action-right {
+  .pficon-add-circle-o{
+    color: $color-pf-blue-400;
+  }
+}

--- a/src/app/toolbar/toolbar-panel.component.ts
+++ b/src/app/toolbar/toolbar-panel.component.ts
@@ -1,0 +1,145 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
+
+import {
+  Filter,
+  FilterConfig,
+  FilterEvent,
+  FilterField,
+  SortConfig,
+  SortEvent,
+  SortField,
+  ToolbarConfig
+} from 'ngx-widgets';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'toolbar-panel',
+  templateUrl: './toolbar-panel.component.html',
+  styleUrls: ['./toolbar-panel.component.scss']
+})
+export class ToolbarPanelComponent implements OnInit {
+  @Input('items') allItems: any[];
+
+  @Output('onAddClick') onAddClick = new EventEmitter();
+  @Output('onFilterChange') onFilterChange = new EventEmitter();
+  @Output('onSortChange') onSortChange = new EventEmitter();
+
+  @ViewChild('add') addTemplate: TemplateRef<any>;
+
+  currentSortField: SortField;
+  filterConfig: FilterConfig;
+  isAscendingSort: boolean = true;
+  items: any[];
+  sortConfig: SortConfig;
+  toolbarConfig: ToolbarConfig;
+
+  constructor() {
+  }
+
+  ngOnInit() {
+    this.items = this.allItems;
+
+    this.filterConfig = {
+      fields: [{
+        id: 'name',
+        title: 'Name',
+        placeholder: 'Filter by Name...',
+        type: 'text'
+      }] as FilterField[],
+      appliedFilters: [],
+      resultsCount: -1, // Hide
+      selectedCount: 0,
+      totalCount: 0,
+      tooltipPlacement: 'right'
+    } as FilterConfig;
+
+    this.sortConfig = {
+      fields: [{
+          id: 'name',
+          title:  'Name',
+          sortType: 'alpha'
+      }],
+      isAscending: this.isAscendingSort
+    } as SortConfig;
+
+    this.toolbarConfig = {
+      filterConfig: this.filterConfig,
+      sortConfig: this.sortConfig
+    } as ToolbarConfig;
+  }
+
+  // Filter functions
+
+  applyFilters(filters: Filter[]): void {
+    this.items = [];
+    if (filters && filters.length > 0) {
+      this.allItems.forEach((item) => {
+        if (this.matchesFilters(item, filters)) {
+          this.items.push(item);
+        }
+      });
+    } else {
+      this.items = this.allItems;
+    }
+    this.toolbarConfig.filterConfig.resultsCount = this.items.length;
+  }
+
+  filterChange($event: FilterEvent): void {
+    this.applyFilters($event.appliedFilters);
+  }
+
+  matchesFilter(item: any, filter: Filter): boolean {
+    let match = true;
+
+    if (filter.field.id === 'name') {
+      match = item.name.match(filter.value) !== null;
+    }
+    return match;
+  }
+
+  matchesFilters(item: any, filters: Filter[]): boolean {
+    let matches = true;
+
+    filters.forEach((filter) => {
+      if (!this.matchesFilter(item, filter)) {
+        matches = false;
+        return false;
+      }
+    });
+    return matches;
+  }
+
+  // Sort functions
+
+  compare(item1: any, item2: any): number {
+    var compValue = 0;
+    if (this.currentSortField.id === 'name') {
+      compValue = item1.name.localeCompare(item2.name);
+    }
+    if (!this.isAscendingSort) {
+      compValue = compValue * -1;
+    }
+    return compValue;
+  }
+
+  sortChange($event: SortEvent): void {
+    this.currentSortField = $event.field;
+    this.isAscendingSort = $event.isAscending;
+    this.items.sort((item1: any, item2: any) => this.compare(item1, item2));
+  }
+
+  // Add button
+
+  onClick($event: MouseEvent): void {
+    this.onAddClick.emit($event);
+  }
+}

--- a/src/app/toolbar/toolbar-panel.module.ts
+++ b/src/app/toolbar/toolbar-panel.module.ts
@@ -1,0 +1,32 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ToolbarPanelComponent } from './toolbar-panel.component';
+
+import {
+  ComponentLoaderFactory,
+  DropdownConfig,
+  DropdownModule,
+  PositioningService,
+  TooltipConfig
+} from 'ng2-bootstrap';
+
+import { ToolbarModule } from 'ngx-widgets';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    DropdownModule,
+    ToolbarModule
+  ],
+  declarations: [
+    ToolbarPanelComponent
+  ],
+  providers: [
+    ComponentLoaderFactory,
+    DropdownConfig,
+    PositioningService,
+    TooltipConfig
+  ],
+  exports: [ToolbarPanelComponent]
+})
+export class ToolbarPanelModule { }

--- a/src/assets/stylesheets/shared/_overrides-for-patternfly.scss
+++ b/src/assets/stylesheets/shared/_overrides-for-patternfly.scss
@@ -3,6 +3,11 @@
 {
   box-shadow: none !important;
 }
+
 .form-control, .btn, .dropdown-menu, .badge {
 font-size: $font-size-base;
+}
+
+.form-control {
+  height: 29px;
 }


### PR DESCRIPTION
I'm creating a PR now for the sake of tomorrow's demo. 

The page displays a simple list view of available codebases associated with the space. If there are none, one will be created -- temporary only for the demo. There is also a panel that slides from the side to associate codebases with the space.

Note that the toolbar filter and sort are not functional right now. The expanding list view rows simply display dummy data in addition to a URL.

![screen shot 2017-03-28 at 11 07 29 pm](https://cloud.githubusercontent.com/assets/17481322/24437090/167e00f2-140d-11e7-8582-1448b7b22d3b.png)
