### PR TITLE
fix(nav): hide secondary nav when empty

### DIFF
--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -4,6 +4,15 @@
 {
   width:100vw !important;
 }
+.navbar-pf .navbar-primary.persistent-secondary {
+  > li {
+    &.active {
+      &.with-no-children {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
 .navbar-nav {
   .pficon-settings {
     margin-top: -5px;


### PR DESCRIPTION
hide the secondary navigation when the active parent does not have any visible child elements

fixes https://github.com/fabric8io/fabric8-ui/issues/454