### PR TITLE
fix(treelist) Upgrading angular-tree-component to 3.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@angularclass/hmr": "1.2.2",
     "@angularclass/hmr-loader": "3.0.2",
     "angular-in-memory-web-api": "0.3.1",
+    "angular-tree-component": "3.2.4",
     "angular-pipes": "6.5.1",
     "angular2-moment": "1.3.3",
     "angular2-oauth2": "1.3.10",


### PR DESCRIPTION
This update takes advantage of Angular 4.

Note that there is a PR for fabric8-ui as well:
https://github.com/fabric8io/fabric8-planner/pull/1505
