### PR TITLE
feat(visuals): upgrade header to match new visual spec

### DIFF
--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -29,3 +29,20 @@
     }
   }
 }
+.navbar-pf .navbar-primary {
+  > .active > a {
+    background-color: $color-pf-black-900;
+    background-image: linear-gradient(to bottom, $color-pf-black-700 0, $color-pf-black-900 100%);
+    border-bottom-color: $color-pf-black-900;
+  }
+  &.persistent-secondary > li > .navbar-persistent {
+    background: $color-pf-black-900;
+    border-bottom: 1px solid $color-pf-black;
+    > li a {
+      color: $color-pf-white;
+      &:hover {
+        color: $color-pf-black-300;
+      }
+    }
+  }
+}

--- a/src/assets/stylesheets/shared/_overrides-for-patternfly.scss
+++ b/src/assets/stylesheets/shared/_overrides-for-patternfly.scss
@@ -4,10 +4,31 @@
   box-shadow: none !important;
 }
 
-.form-control, .btn, .dropdown-menu, .badge {
+.form-control, .btn, .dropdown-menu, .badge, .filter-select {
 font-size: $font-size-base;
 }
 
 .form-control {
   height: 29px;
+}
+
+h1 {
+  font-size: 2em;
+  line-height: 1.3em;
+}
+h2 {
+  font-size: 1.5em;
+  line-height: 1.3em;
+}
+h3 {
+  font-size: 1.3em;
+  line-height: 1.3em;
+}
+h4 {
+  font-size: 1.2em;
+  line-height: 1.3em;
+}
+h5 {
+  font-size: 1.1em;
+  line-height: 1.3em;
 }


### PR DESCRIPTION
Upgrade the header to match the new specs from the visual design team. Coincides with Planner changes.

[Planner Side-Panel PR](https://github.com/fabric8io/fabric8-planner/pull/1537)

Visual Design here: [Holistic View](https://redhat.invisionapp.com/share/N7B74T4MH#/226261730_A-0400)

Screenshot:
<img width="1440" alt="screen shot 2017-04-06 at 11 54 25 am" src="https://cloud.githubusercontent.com/assets/4032718/24763810/7c68516a-1ac0-11e7-9f5c-6e597eb3ee5c.png">