### PR TITLE
fix(codebases): Updated API calls to launch Che

### DIFF
--- a/src/app/create/codebases/codebases-add/codebases-add.component.html
+++ b/src/app/create/codebases/codebases-add/codebases-add.component.html
@@ -21,7 +21,7 @@
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-3">
         <button type="submit" class="btn btn-primary"
-                (click)="fetchCodebase($event)">Fetch</button>
+                (click)="fetchCodebase($event)">Sync</button>
       </div>
     </div>
     <div *ngIf="gitHubRepoDetails !== undefined && gitHubRepoFullNameInvalid !== true">

--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -1,5 +1,8 @@
 <span class="list-group-heading" *ngIf="index === 0">WORKSPACES</span>
-<select class="combobox form-control" [(ngModel)]="workspaceUrl" (ngModelChange)="validateWorkspaceUrl()">
+<select class="combobox form-control"
+        [attr.disabled]="workspaces === undefined || workspaces.length === 0"
+        [(ngModel)]="workspaceUrl"
+        (ngModelChange)="validateWorkspaceUrl()">
   <option value="default">Select a Workspace</option>
   <option *ngFor="let workspace of workspaces" [value]="workspace.links.open">
     {{workspace.attributes.name.length > 0 ? workspace.attributes.name : "Default"}}
@@ -19,7 +22,7 @@
          [attr.disabled]="isHtmlUrlInvalid()"
          (click)="createAndOpenWorkspace()">Create Workspace and Open in Editor</a>
     </li>
-    <li *ngIf="!workspaceUrlInvalid === true" [ngClass]="{'disabled': isHtmlUrlInvalid()}">
+    <li *ngIf="workspaceUrlInvalid !== true" [ngClass]="{'disabled': isHtmlUrlInvalid()}">
       <a href="javascript:void(0)" class="secondary-action"
          [attr.disabled]="isHtmlUrlInvalid()"
          (click)="openWorkspace()">Open Workspace in Editor</a>

--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.ts
@@ -55,9 +55,9 @@ export class CodebasesItemActionsComponent implements OnInit {
         newWindow.location.href = this.workspaceUrl;
 
         // Workspace creation takes a while
-        setTimeout(() => {
-          this.updateWorkspaces(); // Get newly created workspace
-        }, 60000);
+        //setTimeout(() => {
+        //  this.updateWorkspaces(); // Get newly created workspace
+        //}, 60000);
       }
     }, error => {
       this.handleError("Failed to create workspace", NotificationType.DANGER);

--- a/src/app/create/codebases/codebases-item/codebases-item.component.scss
+++ b/src/app/create/codebases/codebases-item/codebases-item.component.scss
@@ -2,3 +2,13 @@
 .list-view-pf-view {
   margin-top: 75px;
 }
+
+.list-view-pf .list-group-item-heading {
+  flex-basis: calc(50% - 20px);
+  width: calc(50% - 20px);
+}
+
+.list-view-pf .list-group-item-text {
+  flex-basis: calc(50% - 40px);
+  width: calc(50% - 40px);
+}

--- a/src/app/create/codebases/services/window.service.ts
+++ b/src/app/create/codebases/services/window.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class WindowService {
+  constructor() {}
+
+  getNativeWindow(): Window {
+    return window;
+  }
+}

--- a/src/app/create/codebases/services/workspace.ts
+++ b/src/app/create/codebases/services/workspace.ts
@@ -1,6 +1,6 @@
 export class Workspace {
   attributes: WorkspaceAttributes;
-  links?: WorkspaceLinks;
+  links?: WorkspaceOpenLinks;
   type: string;
 }
 
@@ -10,5 +10,12 @@ export class WorkspaceAttributes {
 }
 
 export class WorkspaceLinks {
+  links?: {
+    open?: string;
+  }
+}
+
+export class WorkspaceOpenLinks {
   open?: string;
 }
+

--- a/src/app/create/codebases/services/workspaces.service.ts
+++ b/src/app/create/codebases/services/workspaces.service.ts
@@ -61,9 +61,15 @@ export class WorkspacesService {
       });
   }
 
-  openWorkspace(openUrl: string): Observable<WorkspaceLinks> {
+  /**
+   * Open workspace associated with a codebase.
+   *
+   * @param url The open codebase URL (e.g., `${this.workspacesUrl}/${codebaseId}/open/${workspaceId}`)
+   * @returns {Observable<WorkspaceLinks>}
+   */
+  openWorkspace(url: string): Observable<WorkspaceLinks> {
     return this.http
-      .post(openUrl, null, { headers: this.headers })
+      .post(url, null, { headers: this.headers })
       .map(response => {
         return response.json() as WorkspaceLinks;
       })


### PR DESCRIPTION
This updates the codebases page to launch Che in a new window.

Note: I'm able to launch new Che workspaces, but have not been able to launch an existing Che workspace. Aslak believes this is because Che fails to start them properly.