### PR TITLE
fix(codebases): Open existing Che workspace

### DIFF
--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -1,11 +1,11 @@
 <span class="list-group-heading" *ngIf="index === 0">WORKSPACES</span>
 <select class="combobox form-control"
-        [attr.disabled]="workspaces === undefined || workspaces.length === 0"
+        [disabled]="workspacesAvailable === false"
         [(ngModel)]="workspaceUrl"
         (ngModelChange)="validateWorkspaceUrl()">
   <option value="default">Select a Workspace</option>
   <option *ngFor="let workspace of workspaces" [value]="workspace.links.open">
-    {{workspace.attributes.name.length > 0 ? workspace.attributes.name : "Default"}}
+    {{workspace.attributes.name.length > 0 ? workspace.attributes.name : "None"}}
   </option>
 </select>
 <span class="dropdown-kebab-pf" dropdown>

--- a/src/app/create/codebases/codebases-item-details/codebases-item-details.component.ts
+++ b/src/app/create/codebases/codebases-item-details/codebases-item-details.component.ts
@@ -29,7 +29,7 @@ export class CodebasesItemDetailsComponent implements OnInit {
     this.contexts.current.subscribe(val => this.context = val);
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     if (this.codebase == undefined || this.codebase.attributes.type !== 'git') {
       return;
     }
@@ -53,7 +53,7 @@ export class CodebasesItemDetailsComponent implements OnInit {
     this.gitHubService.getRepoLicenseByUrl(this.codebase.attributes.url).subscribe(gitHubRepoLicense => {
       this.license = gitHubRepoLicense.license.name;
     }, error => {
-      this.logger.error("Failed to retrieve GitHub repo license");
+      this.license = "None"
     });
   }
 

--- a/src/app/create/codebases/codebases-item/codebases-item.component.ts
+++ b/src/app/create/codebases/codebases-item/codebases-item.component.ts
@@ -30,7 +30,7 @@ export class CodebasesItemComponent implements OnInit {
     private notifications: Notifications) {
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     if (this.codebase === undefined) {
       return;
     }

--- a/src/app/create/codebases/codebases.component.ts
+++ b/src/app/create/codebases/codebases.component.ts
@@ -42,7 +42,7 @@ export class CodebasesComponent implements OnInit {
       });
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.updateCodebases();
 
     this.emptyStateConfig = {

--- a/src/app/create/codebases/services/window.service.ts
+++ b/src/app/create/codebases/services/window.service.ts
@@ -2,9 +2,29 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class WindowService {
-  constructor() {}
+  private nativeWindow: Window;
 
+  constructor() {
+    this.nativeWindow = window;
+  }
+
+  /**
+   * Get native window
+   *
+   * @returns {Window}
+   */
   getNativeWindow(): Window {
-    return window;
+    return this.nativeWindow;
+  }
+
+  /**
+   * Open an existing window or a newly created one
+   *
+   * @param url The URL of the window to open
+   * @param name The window name
+   * @returns {Window}
+   */
+  open(url: string, name: string): Window {
+    return this.getNativeWindow().open(url, name);
   }
 }


### PR DESCRIPTION
These changes provide the ability to launch an existing Che workspace. If the workspace already exists in an open window, that same window is reused instead of opening multiple new windows. In addition, a window is now only opened if the workspace was created successfully.

Fixes #573, #579, #580, #582

