### PR TITLE
fix(codebases): #539 Updated 'add' panel to mimic mockups

### DIFF
--- a/src/app/create/codebases/codebases-add/codebases-add.component.html
+++ b/src/app/create/codebases/codebases-add/codebases-add.component.html
@@ -19,13 +19,20 @@
       </div>
     </div>
     <div class="form-group">
-      <div class="col-sm-offset-2 col-sm-3">
-        <button type="submit" class="btn btn-primary"
-                (click)="fetchCodebase($event)">Sync</button>
+      <div class="col-sm-11">
+        <div class="details-pull-right">
+          <button type="submit" class="btn btn-primary"
+                  [disabled]="gitHubRepo === undefined || gitHubRepo.trim().length === 0"
+                  (click)="fetchCodebase($event)">Sync</button>
+        </div>
       </div>
     </div>
     <div *ngIf="gitHubRepoDetails !== undefined && gitHubRepoFullNameInvalid !== true">
-      <hr class="col-sm-11">
+      <div class="form-group">
+        <div class="col-sm-11">
+          <div class="details-border"></div>
+        </div>
+      </div>
       <div class="form-group">
         <label for="created" class="col-sm-2 control-label" disabled>Created</label>
         <div class="col-sm-9">
@@ -55,9 +62,11 @@
         </div>
       </div>
       <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-3">
-          <button type="submit" class="btn btn-primary"
-                  (click)="addCodebase($event)">Associate Repository to Space</button>
+        <div class="col-sm-11">
+          <div class="details-pull-right">
+            <button type="submit" class="btn btn-primary"
+                    (click)="addCodebase($event)">Associate Repository to Space</button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/create/codebases/codebases-add/codebases-add.component.scss
+++ b/src/app/create/codebases/codebases-add/codebases-add.component.scss
@@ -1,0 +1,10 @@
+@import '../../../../assets/stylesheets/base';
+
+.details-pull-right {
+  float: right;
+}
+
+.details-border {
+  border-top: 1px solid $color-pf-black-400;
+  margin-left: 35px;
+}


### PR DESCRIPTION
Aligned buttons right of panel.
Added top border between GitHub repo and details.
Disabled sync button for empty repo string to avoid JS errors.

![screen shot 2017-04-10 at 3 04 04 pm](https://cloud.githubusercontent.com/assets/17481322/24877907/f19f6f68-1dfe-11e7-84dd-222a3456aac3.png)

