### PR TITLE
feat(launchpad): moved to the new launchpad quickstarts

### DIFF
--- a/src/app/space-wizard/services/concrete/fabric8-forge.service.ts
+++ b/src/app/space-wizard/services/concrete/fabric8-forge.service.ts
@@ -48,17 +48,14 @@ export class Fabric8ForgeService extends ForgeService {
     // map the forge command system name into the parameters
     switch ( command.name ) {
       case ForgeCommands.forgeStarter: {
-        // TODO when laucnpad is integrated into the back end the command
-        // will change to:
-        //command.parameters.pipeline.name = 'launchpad-new-starer-project';
-        command.parameters.pipeline.name = 'obsidian-new-project';
+        // note that this is now deprecated
+        command.parameters.pipeline.name = 'launchpad-new-starer-project';
         return this.forgeHttpCommandRequest(request);
       }
       case ForgeCommands.forgeQuickStart: {
-        // TODO when laucnpad is integrated into the back end the command
-        // will change to:
-        //command.parameters.pipeline.name = 'launchpad-new-project';
-        command.parameters.pipeline.name = 'fabric8-new-quickstart';
+        command.parameters.pipeline.name = 'launchpad-new-project';
+        // here are the fabric8 upstream quickstarts:
+        //command.parameters.pipeline.name = 'fabric8-new-quickstart';
         return this.forgeHttpCommandRequest(request);
       }
       case ForgeCommands.forgeImportGit: {

--- a/src/app/space-wizard/space-wizard.component.html
+++ b/src/app/space-wizard/space-wizard.component.html
@@ -117,14 +117,13 @@
           </div>
           <div class="section-column">
             <header>
-              <h3>I'd like to use a wizard or QuickStart.</h3>
+              <h3>I'd like to use a Quick Start.</h3>
             </header>
             <section><span><br></span></section>
             <footer class="container-fluid">
               <div class="row">
                 <div class="col-xs-12">
                   <div class="button-bar pull-right">
-                    <a class="btn btn-default" (click)="workflow.gotoNextStep({name:steps.forgeStarter})">Wizard</a>
                     <a class="margin-top-5 btn btn-default" (click)="workflow.gotoNextStep({name:steps.forgeQuickStart})">Quick Start</a>
                   </div>
                 </div>


### PR DESCRIPTION
obsidian is now called launchpad and the 'wizard' is now being removed so we just make quickstarts now - which makes the UI look nicer too ;)
we now have a curated tag of the launchpad stuff so hopefully things won't randomly fail or disappear like when we were stuck on master ;)