### PR TITLE
feat(): Getting started page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -33,6 +33,12 @@ export const routes: Routes = [
     loadChildren: './home/home.module#HomeModule'
   },
 
+  // Getting started
+  {
+    path: '_gettingstarted',
+    loadChildren: './getting-started/getting-started.module#GettingStartedModule'
+  },
+  
   // Error Pages
   {
     path: '_error',

--- a/src/app/getting-started/getting-started-routing.module.ts
+++ b/src/app/getting-started/getting-started-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule }  from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { GettingStartedComponent } from './getting-started.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: GettingStartedComponent
+  }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class GettingStartedRoutingModule {}

--- a/src/app/getting-started/getting-started.component.html
+++ b/src/app/getting-started/getting-started.component.html
@@ -1,0 +1,96 @@
+<div id="overview" class="container content padding-top-15" *ngIf="showGettingStarted">
+  <div class="row">
+    <h1 class="getting-started-title">Getting started in OpenShift.io</h1>
+    <p class="getting-started">
+      Welcome to OpenShift.io! To get started you will need to create a username and connect
+      your GitHub and OpenShift.com accounts.
+    </p>
+    <p class="padding-bottom-15">
+      The fields marked with <span class="required-pf">*</span> are required.
+    </p>
+    <form role="form">
+      <div class="row">
+        <div class="col-md-1">
+          <h2 class="circle">1</h2>
+        </div>
+        <div class="col-md-11 padding-left-0">
+          <h2>Select a username</h2>
+          <div class="form-group">
+            <label for="username" class="control-label required-pf">Username</label>
+            <div [ngClass]="{'has-error': usernameInvalid}">
+              <div class="col-md-5 padding-left-0">
+                <input type="text" class="form-control" id="username" name="username" maxlength="62" required
+                       [disabled]="registrationCompleted"
+                       [(ngModel)]="username"
+                       (change)="updateUsername()">
+              </div>
+              <div class="col-md-7 padding-left-0">
+                <span class="help-block padding-0">
+                Username must be less than 63 characters and can't begin with a dash or underscore. They may contain
+                lowercase letters, numbers, dashes, or underscores.
+              </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-1">
+          <h2 class="circle">2</h2>
+        </div>
+        <div class="col-md-11 padding-left-0">
+          <h2>Connected accounts</h2>
+          <p class="getting-started">
+            This is where we explain that the user must connet their GitHub and OpenShift accounts to OpenShit.io.
+            We also explain all the benefits that come with connecting accounts.
+          </p>
+          <label class="margin-bottom-10" *ngIf="!(gitHubLinked && openShiftLinked)">
+            Select accounts to authorize
+          </label>
+          <label class="margin-bottom-15 required-pf" *ngIf="gitHubLinked && openShiftLinked">
+            Authorized accounts
+          </label>
+          <div class="form-group" *ngIf="!gitHubLinked">
+            <div class="checkbox">
+              <input type="checkbox" id="authGitHub" name="authGitHub"
+                     [(ngModel)]="authGitHub">
+              <label for="authGitHub"class="required-pf">GitHub</label>
+            </div>
+          </div>
+          <div class="form-group" *ngIf="gitHubLinked">
+            <span>You've authorized GitHub.</span>
+          </div>
+          <div class="form-group" *ngIf="!openShiftLinked">
+            <div class="checkbox">
+              <input type="checkbox" id="authOpenShift" name="authOpenShift"
+                     [(ngModel)]="authOpenShift">
+              <label for="authOpenShift" class="required-pf">OpenShift.com</label>
+            </div>
+          </div>
+          <div class="form-group" *ngIf="openShiftLinked">
+            <span>You've authorized OpenShift.com.</span>
+          </div>
+          <div class="form-group">
+            <button class="btn btn-lg btn-default" id="connect"
+                    [disabled]="isConnectAccountsDisabled"
+                    (click)="connectAccounts()">Connect accounts</button>
+          </div>
+        </div>
+      </div>
+      <div class="row" *ngIf="isSuccess">
+        <div class="col-md-12">
+          <div class="success-border">
+            <h2 class="success-title">Success! You're ready to start in OpenShift.io.</h2>
+            <p>
+              Go to your <a [routerLink]="['/', '_home']">home</a> page to start coding, plan work, or do other things.
+              You can also fill out more information about you in your
+              <a [routerLink]="['/', '_home']">profile</a> so that teammates can identify you.
+            </p>
+            <button class="btn btn-lg btn-primary"
+                    (click)="routeToHome()">Get Started</button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/app/getting-started/getting-started.component.scss
+++ b/src/app/getting-started/getting-started.component.scss
@@ -1,0 +1,53 @@
+@import '../../assets/stylesheets/base';
+@import '../../assets/stylesheets/shared/layout';
+
+.checkbox input[type="checkbox"] {
+  margin-left: 0;
+  margin-right: 5px;
+  position: relative;
+}
+
+.checkbox label {
+  padding-left: 0;
+}
+
+.circle {
+  border-radius: 50%;
+  border: 3px solid $color-pf-blue-300;
+  font-weight: 400;
+  height: 50px;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  text-align: center;
+  top: -15px;
+  width: 50px;
+}
+
+.getting-started {
+  padding-bottom: 20px;
+}
+
+.getting-started-title {
+  font-weight: 400;
+}
+
+h2 {
+  margin-top: 0;
+  margin-bottom: 20px;
+  padding-top: 10px;
+}
+
+.help-block {
+  position: relative;
+  top: -10px;
+}
+
+.success-border {
+  border-top: 1px solid $color-pf-black-400;
+  margin-top: 20px;
+  padding-top: 20px;
+}
+
+.success-title {
+  font-weight: 400;
+}

--- a/src/app/getting-started/getting-started.component.ts
+++ b/src/app/getting-started/getting-started.component.ts
@@ -1,0 +1,187 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
+
+import { Logger, Notification, NotificationType, Notifications } from 'ngx-base';
+import { AuthenticationService, UserService, User } from 'ngx-login-client';
+
+import { ExtUser, GettingStartedService } from './services/getting-started.service';
+import { ProviderService } from './services/provider.service';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'alm-getting-started',
+  templateUrl: './getting-started.component.html',
+  styleUrls: ['./getting-started.component.scss'],
+  providers: [ GettingStartedService, ProviderService ]
+})
+export class GettingStartedComponent implements OnInit {
+
+  authGitHub: boolean = false;
+  authOpenShift: boolean = false;
+  gettingStartedCompleted: boolean = false;
+  gitHubLinked: boolean = false;
+  loggedInUser: User;
+  openShiftLinked: boolean = false;
+  registrationCompleted: boolean = false;
+  showGettingStarted: boolean = false;
+  username: string;
+  usernameInvalid: boolean = false;
+
+  constructor(
+      private auth: AuthenticationService,
+      private gettingStartedService: GettingStartedService,
+      private logger: Logger,
+      private providerService: ProviderService,
+      private notifications: Notifications,
+      private router: Router,
+      private userService: UserService) {
+    userService.loggedInUser.subscribe(user => {
+      if (user === undefined || user.attributes === undefined) {
+        return;
+      }
+      this.loggedInUser = user;
+      this.username = this.loggedInUser.attributes.username;
+      this.registrationCompleted = (user as ExtUser).attributes.registrationCompleted;
+    });
+    auth.gitHubToken.subscribe(token => {
+      this.gitHubLinked = (token !== undefined && token.length !== 0);
+    });
+    auth.openShiftToken.subscribe(token => {
+      this.openShiftLinked = (token !== undefined && token.length !== 0);
+    });
+    this.isGettingStarted().subscribe(val => {
+      this.showGettingStarted = val;
+      if (!this.showGettingStarted) {
+        this.routeToHome();
+      }
+    });
+  }
+
+  ngOnInit() {
+  }
+
+  /**
+   * Helper to test if connect accounts button should be disabled
+   *
+   * @returns {boolean}
+   */
+  get isConnectAccountsDisabled(): boolean {
+    return !(this.authGitHub && !this.gitHubLinked || this.authOpenShift && !this.openShiftLinked)
+      || (this.gitHubLinked && this.openShiftLinked);
+  }
+
+  /**
+   * Helper to test if the successful state panel should be shown
+   *
+   * @returns {boolean} If the user has completed the getting started page
+   */
+  get isSuccess(): boolean {
+    return !this.usernameInvalid && this.gitHubLinked && this.openShiftLinked;
+  }
+
+  // Actions
+
+  /**
+   * Link GitHub and/or OpenShift accounts
+   */
+  connectAccounts(): void {
+    if (this.authGitHub && !this.gitHubLinked && this.authOpenShift && !this.openShiftLinked) {
+      this.providerService.linkAll(window.location.origin + "/_gettingstarted?wait=true");
+    } else if (this.authGitHub && !this.gitHubLinked) {
+      this.providerService.linkGitHub(window.location.origin + "/_gettingstarted?wait=true");
+    } else if (this.authOpenShift && !this.openShiftLinked) {
+      this.providerService.linkOpenShift(window.location.origin + "/_gettingstarted?wait=true");
+    }
+  }
+
+  /**
+   * Helpfer to route to home page
+   */
+  routeToHome(): void {
+    this.router.navigate(['/', '_home']);
+  }
+
+  /**
+   * Update username
+   *
+   * Note: This can only be done once per the user patch API
+   */
+  updateUsername(): void {
+    this.usernameInvalid = !this.isUsernameValid();
+    if (this.usernameInvalid) {
+      return;
+    }
+    let profile = this.gettingStartedService.createTransientProfile();
+    profile.username = this.username;
+
+    this.gettingStartedService.update(profile).subscribe(user => {
+      this.loggedInUser = user;
+      if (this.username === user.attributes.username) {
+        this.notifications.message({
+          message: `Username updated!`,
+          type: NotificationType.SUCCESS
+        } as Notification);
+      }
+    }, error => {
+      this.username = this.loggedInUser.attributes.username;
+      if (error.status === 403) {
+        this.handleError("Username cannot be updated more than once", NotificationType.WARNING);
+      } else {
+        this.handleError("Failed to update username", NotificationType.DANGER);
+      }
+    });
+  }
+
+  // Private
+
+  /**
+   * Helper to retrieve request parameters
+   *
+   * @param name The request parameter to retrieve
+   * @returns {any} The request parameter value or null
+   */
+  private getRequestParam(name: string): string {
+    let param = (new RegExp('[?&]' + encodeURIComponent(name) + '=([^&]*)')).exec(window.location.search);
+    if (param != null) {
+      return decodeURIComponent(param[1]);
+    }
+    return null;
+  }
+
+  /**
+   * Helper to determine if getting started page should be shown or forward to the home page.
+   *
+   * @returns {Observable<boolean>}
+   */
+  private isGettingStarted(): Observable<boolean> {
+    let wait = this.getRequestParam("wait");
+    return Observable.combineLatest(
+      Observable.of(wait).map(val => val),
+      Observable.of(this.gitHubLinked).map(val => val),
+      Observable.of(this.openShiftLinked).map(val => val),
+      (a, b, c) => !(a === null && b === true && c === true)
+    );
+  }
+
+  /**
+   * Helper to test if username is valid
+   *
+   * @returns {boolean}
+   */
+  private isUsernameValid(): boolean {
+    // Dot and @ characters are valid
+    return (this.username !== undefined
+      && this.username.trim().length !== 0
+      && this.username.trim().length < 63
+      && this.username.trim().indexOf("-") === -1
+      && this.username.trim().indexOf("_") === -1);
+  }
+
+  private handleError(error: string, type: NotificationType) {
+    this.notifications.message({
+      message: error,
+      type: type
+    } as Notification);
+  }
+}

--- a/src/app/getting-started/getting-started.module.ts
+++ b/src/app/getting-started/getting-started.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { GettingStartedComponent } from './getting-started.component';
+import { GettingStartedRoutingModule } from './getting-started-routing.module';
+
+@NgModule({
+  imports: [ CommonModule, FormsModule, GettingStartedRoutingModule ],
+  declarations: [ GettingStartedComponent ],
+})
+export class GettingStartedModule {
+  constructor() {}
+}

--- a/src/app/getting-started/services/getting-started.service.ts
+++ b/src/app/getting-started/services/getting-started.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Inject } from '@angular/core';
+import { Headers, Http } from '@angular/http';
+import { Observable } from 'rxjs';
+
+import { Logger } from 'ngx-base';
+import { AuthenticationService, Profile, User, UserService } from 'ngx-login-client';
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+
+import { cloneDeep } from 'lodash';
+
+export class ExtUser extends User {
+  attributes: ExtProfile;
+}
+
+export class ExtProfile extends Profile {
+  contextInformation: any;
+  registrationCompleted: boolean;
+}
+
+@Injectable()
+export class GettingStartedService {
+  private headers = new Headers({ 'Content-Type': 'application/json' });
+  private loggedInUser: User;
+  private usersUrl: string;
+
+  constructor(
+      private auth: AuthenticationService,
+      private http: Http,
+      private logger: Logger,
+      private userService: UserService,
+      @Inject(WIT_API_URL) apiUrl: string) {
+    userService.loggedInUser.subscribe(user => {
+      if (user !== undefined && user.attributes !== undefined) {
+        this.loggedInUser = user;
+      }
+    });
+    if (this.auth.getToken() != null) {
+      this.headers.set('Authorization', 'Bearer ' + this.auth.getToken());
+    }
+    this.usersUrl = apiUrl + 'users';
+  }
+
+  /**
+   * Create transient profile with context information
+   *
+   * @returns {ExtProfile}
+   */
+  createTransientProfile(): ExtProfile {
+    let profile = cloneDeep(this.loggedInUser) as ExtUser;
+
+    if(profile.attributes) {
+      profile.attributes.contextInformation = (this.loggedInUser as ExtUser).attributes.contextInformation || {};
+    } else {
+      profile.attributes = {
+        "contextInformation": {},
+        "fullName": "",
+        "imageURL": "",
+        "username": "",
+        "registrationCompleted": false
+      };
+    }
+    return profile.attributes;
+  }
+
+  /**
+   * Get extended profile for given user ID
+   *
+   * @param id The user ID
+   * @returns {Observable<ExtUser>}
+   */
+  getExtProfile(id: string): Observable<ExtUser> {
+    let url = `${this.usersUrl}/${id}`;
+    return this.http
+      .get(url, { headers: this.headers })
+      .map(response => {
+        return response.json().data as ExtUser;
+      })
+      .catch((error) => {
+        return this.handleError(error);
+      });
+  }
+
+  /**
+   * Update user profile
+   *
+   * @param profile The extended profile used to apply context information
+   * @returns {Observable<User>}
+   */
+  update(profile: ExtProfile): Observable<ExtUser> {
+    let payload = JSON.stringify({
+      data: {
+        attributes: profile,
+        type: 'identities'
+      }
+    });
+    return this.http
+      .patch(this.usersUrl, payload, { headers: this.headers })
+      .map(response => {
+        return response.json().data as ExtUser;
+      })
+      .catch((error) => {
+        return this.handleError(error);
+      });
+  }
+
+  // Private
+
+  private handleError(error: any) {
+    this.logger.error(error);
+    return Observable.throw(error.message || error);
+  }
+}

--- a/src/app/getting-started/services/provider.service.ts
+++ b/src/app/getting-started/services/provider.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, Inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { AuthenticationService } from 'ngx-login-client';
+import { Logger } from 'ngx-base';
+import { WIT_API_URL } from 'ngx-fabric8-wit';
+
+@Injectable()
+export class ProviderService {
+  private loginUrl: string;
+
+  constructor(
+      private auth: AuthenticationService,
+      private logger: Logger,
+      @Inject(WIT_API_URL) apiUrl: string) {
+    this.loginUrl = apiUrl + 'login';
+  }
+
+  /**
+   * Link an OpenShit.com account to the user account
+   *
+   * @param redirect URL to be redirected to after successful account linking
+   */
+  linkAll(redirect: string): void {
+    this.link(null, redirect);
+  }
+
+  /**
+   * Link a GitHub account to the user account
+   *
+   * @param redirect URL to be redirected to after successful account linking
+   */
+  linkGitHub(redirect: string): void {
+    this.link("github", redirect);
+  }
+
+  /**
+   * Link an OpenShit.com account to the user account
+   *
+   * @param redirect URL to be redirected to after successful account linking
+   */
+  linkOpenShift(redirect: string): void {
+    this.link("openshift-v3", redirect);
+  }
+
+  /**
+   * Link an Identity Provider account to the user account
+   *
+   * @param provider Identity Provider name to link to the user's account
+   * @param redirect URL to be redirected to after successful account linking
+   */
+  link(provider: string, redirect: string): void {
+    let parsedToken = this.parseJwt(this.auth.getToken());
+    let url = `${this.loginUrl}/linksession?`
+      + "clientSession=" + parsedToken.client_session
+      + "&sessionState=" + parsedToken.session_state
+      + "&redirect=" + redirect;
+    if (provider != null) {
+      url += "&provider=" + provider;
+    }
+    this.redirectToAuth(url);
+  }
+
+  // Private
+
+  /**
+   * Helper to parse JWT token
+   *
+   * @param token
+   * @returns {any} The parsed JWT token
+   */
+  private parseJwt(token) {
+    var base64Url = token.split('.')[1];
+    var base64 = base64Url.replace('-', '+').replace('_', '/');
+    return JSON.parse(window.atob(base64));
+  };
+
+  private redirectToAuth(url) {
+    window.location.href = url;
+  }
+
+  private handleError(error: any) {
+    this.logger.error(error);
+    return Observable.throw(error.message || error);
+  }
+}

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-inverse navbar-pf" role="navigation" *ngIf="context">
+<nav class="navbar navbar-inverse navbar-pf" role="navigation" *ngIf="context && !isGettingStartedPage">
   <div class="navbar-header">
     <ul class="nav navbar-nav navbar-right hidden-sm hidden-md hidden-lg ">
       <li dropdown class="pull-right dropdown" *ngIf="loggedInUser">

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -121,6 +121,10 @@ export class HeaderComponent implements OnInit {
     }
   }
 
+  get isGettingStartedPage(): boolean {
+    return (this.router.url.indexOf("_gettingstarted") !== -1);
+  }
+
   private updateMenus() {
     if (this.context && this.context.type && this.context.type.hasOwnProperty('menus')) {
       for (let n of (this.context.type as MenuedContextType).menus) {

--- a/src/app/landing-page/landing-page.component.ts
+++ b/src/app/landing-page/landing-page.component.ts
@@ -30,7 +30,7 @@ export class LandingPageComponent implements OnInit {
   }
 
   login() {
-    this.loginService.redirectUrl = '/_home';
+    this.loginService.redirectUrl = '/_gettingstarted';
     this.broadcaster.broadcast('login');
     this.loginService.redirectToAuth();
   }

--- a/src/app/profile/overview/overview.component.html
+++ b/src/app/profile/overview/overview.component.html
@@ -113,7 +113,8 @@
     </div>
     <!-- right column -->
     <div class="col-md-2">
-      <button class="btn btn-lg btn-default width-100">Update Profile</button>
+      <button class="btn btn-lg btn-default width-100"
+              (click)="routeToUpdateProfile()">Update Profile</button>
     </div>
   </div>
 </div>

--- a/src/app/profile/overview/overview.component.ts
+++ b/src/app/profile/overview/overview.component.ts
@@ -25,4 +25,7 @@ export class OverviewComponent implements OnInit {
 
   }
 
+  routeToUpdateProfile(): void {
+    this.router.navigate(['/', this.context.user.attributes.username, "_update"]);
+  }
 }

--- a/src/app/profile/profile-routing.module.ts
+++ b/src/app/profile/profile-routing.module.ts
@@ -11,7 +11,8 @@ const routes: Routes = [
     children: [
       { path: '', component: OverviewComponent },
       { path: '_spaces', loadChildren: './spaces/spaces.module#SpacesModule' },
-      { path: '_resources', loadChildren: './resources/resources.module#ResourcesModule' }
+      { path: '_resources', loadChildren: './resources/resources.module#ResourcesModule' },
+      { path: '_update', loadChildren: './update/update.module#UpdateModule' }
     ]
   }
 ];

--- a/src/app/profile/update/update-routing.module.ts
+++ b/src/app/profile/update/update-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule }  from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { UpdateComponent } from './update.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: UpdateComponent
+  }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class UpdateRoutingModule {}

--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -1,0 +1,120 @@
+<div id="overview" class="container content padding-top-15">
+  <div class="row">
+    <h1>Profile</h1>
+    <!-- left column -->
+    <div class="col-md-2">
+      <div class="row">
+        <div class="width-100">
+          <section class="profile-image-overlay posRel">
+            <img src="{{context?.user?.attributes?.imageURL}}" class="width-100 profile-img" />
+          </section>
+          <section>
+            <h2 class="pull-left">{{context?.user?.attributes?.fullName}}</h2>
+          </section>
+          <p>
+            {{context?.user?.attributes?.username}}
+          </p>
+          <hr/>
+          <p class="profile-email-wrapper">
+            <span class="fa fa-envelope"></span>
+            <a href="javascript:void(0)" class="margin-left-5 margin-right-5"
+               (click)="setElementFocus($event, _email)">Add an email</a>
+          </p>
+          <p>
+            <span class="fa fa-external-link"></span>
+            <a href="javascript:void(0)" class="margin-left-5 margin-right-5"
+               (click)="setElementFocus($event, _email)">Add a url</a>
+          </p>
+          <a href="javascript:void(0)" class="margin-left-5 margin-right-5"
+             (click)="setElementFocus($event, _email)">Add a bio</a>
+        </div>
+      </div>
+    </div>
+    <!-- center column -->
+    <div class="col-md-8">
+      <form class="col-sm-8" role="form">
+        <p class="fields-status-pf">The fields marked with <span class="required-pf">*</span> are required.</p>
+        <h2>Your profile</h2>
+        <div class="form-group">
+          <label for="username" class="control-label required-pf">Username</label>
+          <div [ngClass]="{'has-error': usernameInvalid === true}">
+            <input type="text" class="form-control" id="username" name="username" required
+                   [(ngModel)]="username">
+            <span class="help-block">
+              Username must be less than 63 characters and can't begin with a dash or underscore. They may contain
+              lowercase letters, numbers, dashes, or underscores.
+            </span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="name" class="control-label">Name</label>
+          <div [ngClass]="{'has-error': nameInvalid === true}">
+            <input type="text" class="form-control" id="name" name="name"
+                   [(ngModel)]="name">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="hideName" class="sr-only">Hide name</label>
+          <div class="checkbox">
+            <input type="checkbox" id="hideName" name="hideName"
+                   [(ngModel)]="hideName">Don't show my name
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="name" class="control-label">Email</label>
+          <div [ngClass]="{'has-error': emailInvalid === true}">
+            <input type="text" class="form-control" id="email" name="email" #_email
+                   [(ngModel)]="email">
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="hideName" class="sr-only">Hide email</label>
+          <div class="checkbox">
+            <input type="checkbox" id="hideEmail" name="hideEmail"
+                   [(ngModel)]="hideEmail">Don't show this email
+          </div>
+        </div>
+        <h2 class="margin-top-40">Connected accounts</h2>
+        <p class="getting-started">
+          This is where we explain that the user must connet their GitHub and OpenShift accounts to OpenShit.io. We also
+          explain all the benefits that come with connecting accounts.
+        </p>
+        <div class="form-group">
+          <label for="github" class="control-label required-pf">GitHub</label>
+          <div>
+            <button class="btn btn-lg btn-default" id="github"
+                    (click)="redirectToGitHubAuth()">Connect GitHub account</button>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="openshift" class="control-label required-pf">OpenShift</label>
+          <div>
+            <button class="btn btn-lg btn-default" id="openshift"
+                    (click)="redirectToOpenShiftAuth()">Connect OpenShift account</button>
+          </div>
+        </div>
+        <!--
+        <fieldset class="fields-section-pf" id="test">
+          <legend class="fields-section-header-pf">
+            <span class="fa fa-angle-right fa-angle-down field-section-toggle-pf"></span>
+            <a href="#test" class="field-section-toggle-pf">Advanced Options</a>
+          </legend>
+          <div class="form-group">
+            <label class="col-sm-2 control-label" for="">Entry Point 1</label>
+            <div class="col-sm-10">
+              <input type="text" id="" class="form-control"></div>
+          </div>
+        </fieldset>
+        -->
+      </form>
+    </div>
+    <!-- right column -->
+    <div class="col-md-2">
+      <button class="btn btn-lg btn-default width-100" disabled>Update Profile</button>
+      <div class="margin-top-5">
+        <button class="btn btn-lg btn-default width-100"
+          (click)="routeToProfile()">Cancel</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/profile/update/update.component.scss
+++ b/src/app/profile/update/update.component.scss
@@ -1,0 +1,20 @@
+@import '../../../assets/stylesheets/base';
+@import '../../../assets/stylesheets/shared/layout';
+
+.checkbox input[type="checkbox"] {
+  margin-left: 0;
+  margin-right: 5px;
+  position: relative;
+}
+
+.fields-status-pf {
+  margin-top: -5px;
+}
+
+.getting-started {
+  padding-bottom: 20px;
+}
+
+.margin-top-40 {
+  margin-top: 40px;
+}

--- a/src/app/profile/update/update.component.ts
+++ b/src/app/profile/update/update.component.ts
@@ -1,0 +1,54 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { NavigationStart, Router  } from '@angular/router';
+
+import { Context, Contexts } from 'ngx-fabric8-wit';
+import { UserService, User } from 'ngx-login-client';
+
+@Component({
+  selector: 'alm-update',
+  templateUrl: 'update.component.html',
+  styleUrls: ['./update.component.scss']
+})
+export class UpdateComponent implements OnInit {
+
+  context: Context;
+  email: string;
+  emailInvalid: boolean = false;
+  hideName: boolean = false;
+  hideEmail: boolean = false;
+  loggedInUser: User;
+  name: string;
+  nameInvalid: boolean = false;
+  username: string;
+  usernameInvalid: boolean = false;
+
+  constructor(
+      private contexts: Contexts,
+      private router: Router,
+      userService: UserService) {
+    contexts.current.subscribe(val => this.context = val);
+    userService.loggedInUser.subscribe(val => {
+      this.loggedInUser = val;
+    });
+  }
+
+  ngOnInit() {
+
+  }
+
+  setElementFocus($event: MouseEvent, element: HTMLElement) {
+    element.focus();
+  }
+
+  redirectToGitHubAuth(): void {
+
+  }
+
+  redirectToOpenShiftAuth(): void {
+
+  }
+
+  routeToProfile(): void {
+    this.router.navigate(['/', this.context.user.attributes.username]);
+  }
+}

--- a/src/app/profile/update/update.module.ts
+++ b/src/app/profile/update/update.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpModule, Http } from '@angular/http';
+
+import { UpdateComponent } from './update.component';
+import { UpdateRoutingModule } from './update-routing.module';
+
+@NgModule({
+  imports: [ CommonModule, FormsModule, UpdateRoutingModule, HttpModule ],
+  declarations: [ UpdateComponent ],
+})
+export class UpdateModule {
+  constructor(http: Http) {}
+}

--- a/src/app/shared/login.service.ts
+++ b/src/app/shared/login.service.ts
@@ -38,7 +38,8 @@ export class LoginService {
     private notifications: Notifications,
     private userService: UserService
   ) {
-    this.authUrl = apiUrl + 'login/authorize?link=true';
+    // Removed ?link=true in favor of getting started page
+    this.authUrl = apiUrl + 'login/authorize';
     this.broadcaster.on('authenticationError').subscribe(() => {
       this.authService.logout();
     });


### PR DESCRIPTION
This PR is for the getting started page and an initial update profile page. 

The issues with the linking APIs have been resolved by changing the workflow a bit. The fabric8-ui landing page now redirects to the getting started page instead of home. I also removed the login/authorize?link=true param from the login service URL to allow the getting started page to perform linking instead.

Note that we cannot not redirect to an external URL and provide an authorization header. Therefore, instead of using /login/link, I'm using /login/linksession and parsing the JWT token. The clientSession and sessionState are provided as query params. 

That said, I'm now able to link GitHub and OpenShift together. I can also link GitHub and OpenShift separately.

The username can only be updated once, which is enforced by the user patch API.

The update profile page is non-functional -- layout only right now.

Success snapshot:
![screen shot 2017-04-17 at 8 32 02 pm](https://cloud.githubusercontent.com/assets/17481322/25109785/4a4f32f2-23ad-11e7-906e-0dba88bfbb0a.png)

Individual linking snapshot:
![screen shot 2017-04-17 at 8 33 34 pm](https://cloud.githubusercontent.com/assets/17481322/25109783/44b9d608-23ad-11e7-8434-56131cc30dea.png)

Update Profile
![screen shot 2017-04-17 at 8 39 47 pm](https://cloud.githubusercontent.com/assets/17481322/25109883/15965756-23ae-11e7-9ad4-ac817d084f91.png)
