### PR TITLE
fix(dashboards): set background color to match card rows

### DIFF
--- a/src/app/analyze/analyze-overview/analyze-overview.component.scss
+++ b/src/app/analyze/analyze-overview/analyze-overview.component.scss
@@ -1,2 +1,7 @@
 @import '../../../assets/stylesheets/base';
 @import '../../../assets/stylesheets/shared/layout';
+
+.analyze-overview-wrapper {
+  background-color: $color-pf-black-150;
+  height: 100%;
+}

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,5 +1,7 @@
 @import '../../assets/stylesheets/base';
 .home-wrapper {
+  background-color: $color-pf-black-150;
+  height: 100%;
   padding-top: 2rem;
   .pf-icon-home {
     font-size: $pf-icon-4x;


### PR DESCRIPTION
set the background color to match the card rows in order to give a seamless view.

there is no Issue for this - change came out of UX sync.