### PR TITLE
fix(analytics_report): change the look of stack report as per ux

### DIFF
--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.html
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.html
@@ -2,32 +2,76 @@
   <div class="card-pf-heading">
     <h2 class="card-pf-title">Stack Report</h2>
   </div>
-  <div class="card-pf-body card-f8-body">
-    <form>
-      <div class="form-group">
-        <!--<div class="combobox-container">
-          <input type="hidden" name="" value="">
-          <div class="input-group col-sm-7">
-            <input type="text" autocomplete="false" placeholder="Select your build/pipeline" class="combobox form-control">
-            <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown">
-              <span class="caret"></span>
-              <span class="glyphicon glyphicon-remove"></span>
-            </span>
+  <div class="card-pf-body card-f8-body analytical-report-body">
+    <div *ngIf="buildConfigs" class="pipelines-present">
+      <form>
+        <div class="form-group row">
+          <!--<div class="combobox-container">
+            <input type="hidden" name="" value="">
+            <div class="input-group col-sm-7">
+              <input type="text" autocomplete="false" placeholder="Select your build/pipeline" class="combobox form-control">
+              <span class="input-group-addon dropdown-toggle" data-dropdown="dropdown">
+                <span class="caret"></span>
+                <span class="glyphicon glyphicon-remove"></span>
+              </span>
+            </div>
+          </div>-->
+          <div class="col-xs-12 col-md-4">
+            <select name="pipeSelect" [(ngModel)]="currentPipeline" (change)="selectedPipeline()" class="combobox form-control">
+              <option value="" selected disabled>Select pipeline</option>
+              <option *ngFor="let build of buildConfigs | async" [ngValue]="build">{{ build.name }}</option>
+            </select>
           </div>
-        </div>-->
-        <select name="pipeSelect" [(ngModel)]="currentPipeline" (change)="selectedPipeline()" class="combobox form-control">
-          <option value="" selected="selected">select your build/pipeline</option>
-          <option *ngFor="let build of buildConfigs | async" [ngValue]="build">{{ build.name }}</option>
-        </select>
-      </div>
-    </form>
-    <div class="pipeline-builds">
-      <div *ngFor="let build of currentPipelineBuilds">
-        <a>Build #{{build.buildNumber}}</a>
-        <div *ngIf="build && build.annotations && build.annotations['fabric8.io/bayesian.analysisUrl']">
-          You can view the stack analysis reports here: <stack-details *ngIf="build && build.annotations && build.annotations['fabric8.io/bayesian.analysisUrl']" [stack]="build && build.annotations && build.annotations['fabric8.io/bayesian.analysisUrl']"></stack-details>
+          <div class="col-xs-12 col-md-4">
+            <select name="buildSelect" [(ngModel)]="currentBuild" (change)="selectedBuild()" class="combobox form-control">
+              <option value="1" selected disabled>Select build</option>
+              <option *ngFor="let build of currentPipelineBuilds" [ngValue]="build">Build #{{ build.buildNumber }}</option>
+            </select>
+          </div>
         </div>
+      </form>
+      <div class="pipeline-builds row">
+        <div *ngIf="currentBuild" class="col-xs-12">
+          <div *ngIf="currentBuild && currentBuild.annotations && currentBuild.annotations['fabric8.io/bayesian.analysisUrl']">
+            <div class="fabric8-stack-analysis" *ngIf="stackAnalysisInformation['recommendations']">
+              <div class="recommendation-header">
+                <h1 class="keep-left">Recommendations <small>(only <b>top-{{stackAnalysisInformation.recommendationsLimit}}</b>)</small></h1>
+              </div>
+              <div class="list-group-item list-view-pf-stacked recommendation-group-item recommendation-list" *ngFor="let recommendation of stackAnalysisInformation['recommendations']">
+                <div class="list-view-pf-main-info">
+                  <div class="list-view-pf-left">
+                    <span class="pficon pficon-info"></span>
+                  </div>
+                  <div class="list-view-pf-body">
+                    <div class="list-view-pf-description">
+                      <div class="list-group-item-text">
+                        {{recommendation.suggestion}}: {{recommendation.action}} {{recommendation.message}}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="recommendation-list" *ngIf="!stackAnalysisInformation['recommendations'] || stackAnalysisInformation['recommendations'].length === 0">
+                <div class="no-recommendations list-view-pf-main-info">
+                  <div class="list-view-pf-left">
+                    <span class="pficon pficon-info"></span>
+                  </div>
+                  <div class="list-view-pf-body">
+                    <b>No recommendations.</b> &nbsp; Your stack looks great.
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!--You can view the stack analysis reports here: <stack-details *ngIf="build && build.annotations && build.annotations['fabric8.io/bayesian.analysisUrl']" [stack]="build && build.annotations && build.annotations['fabric8.io/bayesian.analysisUrl']"></stack-details>
+        --></div>
+          <div *ngIf="!currentBuild">No records found</div>
+        </div>
+        <div class="col-xs-12" *ngIf="!currentBuild">No records found</div>
       </div>
+    </div>
+    <div *ngIf="!buildConfigs" class="pipelines-absent">
+      <h2>No results found</h2>
+      <p>When you run a build, a stack analysis is run that will provide recommendations around your technology stack</p>
     </div>
   </div>
   <div class="card-pf-footer card-f8-footer">

--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.scss
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.scss
@@ -1,1 +1,39 @@
 @import '../../../assets/stylesheets/base';
+
+@mixin transform-translate($x, $y) {
+    -webkit-transform: translate($x, $y);
+      -ms-transform: translate($x, $y);
+          transform: translate($x, $y);
+}
+
+.card-pf-body {
+    min-height: 360px;
+    &.analytical-report-body {
+        .fabric8-stack-analysis {
+            .recommendation-list {
+                .list-view-pf-main-info {
+                    margin-bottom: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-top: 0;
+                    &.no-recommendations {
+                        background: $color-pf-black-100;
+                        padding: 10px;
+                        border: 1px solid $color-pf-black-150;
+                    }
+                }
+            }
+        }
+        .pipelines-absent {
+            width: 50%;
+            margin: 0 auto;
+            text-align: center;
+            top: 20%;
+            position: relative;
+            @include transform-translate(0%, -20%);
+            h2 {
+                margin: 0 0 40px 0;
+            }
+        }
+    }
+}

--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.ts
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.ts
@@ -12,10 +12,15 @@ import {
   Build
 } from 'fabric8-runtime-console';
 
+import {StackAnalysesService, getStackRecommendations} from 'fabric8-stack-analysis-ui';
+
 @Component({
   selector: 'fabric8-analytical-report-widget',
   templateUrl: './analytical-report-widget.component.html',
-  styleUrls: ['./analytical-report-widget.component.scss']
+  styleUrls: ['./analytical-report-widget.component.scss'],
+  providers: [
+    StackAnalysesService
+  ]
 })
 export class AnalyticalReportWidgetComponent implements OnInit {
 
@@ -25,10 +30,16 @@ export class AnalyticalReportWidgetComponent implements OnInit {
   currentPipeline: BuildConfig;
   currentPipelineBuilds: Array<Build>;
 
+  currentBuild: Build;
+  stackAnalysisInformation: any = {
+    recommendationsLimit: 5
+  };
+
   constructor(
     private context: Contexts,
     private broadcaster: Broadcaster,
-    private pipelinesService: PipelinesService
+    private pipelinesService: PipelinesService,
+    private stackAnalysisService: StackAnalysesService
   ) { }
 
   ngOnInit() {
@@ -43,7 +54,52 @@ export class AnalyticalReportWidgetComponent implements OnInit {
 
   selectedPipeline(): void {
     let pipeline: BuildConfig = this.currentPipeline;
-    this.currentPipelineBuilds = pipeline.interestingBuilds;
+    this.currentPipelineBuilds = pipeline.builds;
+  }
+
+  selectedBuild(): void {
+    let build: Build = this.currentBuild;
+    if (build.annotations['fabric8.io/bayesian.analysisUrl']) {
+      let url: string = build.annotations['fabric8.io/bayesian.analysisUrl'];
+      this.stackAnalysisService
+          .getStackAnalyses(url)
+          .subscribe((data) => {
+            let recommendationsObservable = getStackRecommendations(data);
+            if (recommendationsObservable) {
+              let recommendations: Array<any> = [];
+              recommendationsObservable.subscribe((result) => {
+                let missing: Array<any> = result.missing || [];
+                let version: Array<any> = result.version || [];
+
+
+                for (let i in missing) {
+                  if (missing.hasOwnProperty(i)) {
+                    let keys: Array<string> = Object.keys(missing[i]);
+                    recommendations.push({
+                      suggestion: 'Recommendation',
+                      action: 'Add',
+                      message: keys[0] + ' : ' + missing[i][keys[0]]
+                    });
+                  }
+                }
+                for (let i in version) {
+                  if (version.hasOwnProperty(i)) {
+                    let keys: Array<string> = Object.keys(version[i]);
+                    recommendations.push({
+                      suggestion: 'Recommendation',
+                      action: 'Update',
+                      message: keys[0] + ' : ' + version[i][keys[0]]
+                    });
+                  }
+                }
+
+                this.stackAnalysisInformation['recommendations'] = recommendations;
+                // Restrict the recommendations to a particular limit as specified in UX
+                this.stackAnalysisInformation['recommendations'].splice(this.stackAnalysisInformation['recommendationsLimit']);
+              });
+            }
+        });
+      }
   }
 
 }

--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.module.ts
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.module.ts
@@ -4,7 +4,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-
 @NgModule({
   imports: [CommonModule, FormsModule, StackDetailsModule],
   declarations: [AnalyticalReportWidgetComponent],


### PR DESCRIPTION

<img width="1172" alt="screen shot 2017-04-18 at 11 02 39 pm" src="https://cloud.githubusercontent.com/assets/7880465/25144930/2d3635cc-248d-11e7-836f-cf6356fb650e.png">
<img width="1116" alt="screen shot 2017-04-18 at 11 01 36 pm" src="https://cloud.githubusercontent.com/assets/7880465/25144931/2d63caa0-248d-11e7-9e2c-a2a9eb9299a4.png">

Changes:

1. Introduces Changes in analytical-report-widget.component.html
	a. Select boxes for selecting pipelines and builds if present
	b. On selecting, show the stack analysis information if any
2. Uses exposed bayesian functions to get recommendations while hitting its API - analytical-report-widget.component.ts
3. Changes in styles to support the HTMLs - analytical-report-widget.component.scss

Fixes #814.

Added a few screenshots to highlight the changes visually. (This is because not everyone can see all the flows, you require build associated to see specific analysis)