### PR TITLE
fix(header): Removed settings, home, and profile

### DIFF
--- a/src/app/header/menus.service.ts
+++ b/src/app/header/menus.service.ts
@@ -12,44 +12,6 @@ export class MenusService {
   constructor() {
     this.menus = new Map<ContextType, MenuItem[]>([
       [
-        ContextTypes.BUILTIN.get('user'),
-        [
-          {
-            path: '_settings',
-            icon: 'pficon pficon-settings',
-            menus: [
-              {
-                name: 'Profile',
-                path: ''
-              },
-              {
-                name: 'Access Tokens',
-                path: 'tokens'
-              }
-            ]
-          },
-          {
-            name: 'Home',
-            path: '/_home'
-          }, {
-            name: 'Profile',
-            path: '',
-            menus: [
-              {
-                name: 'Profile',
-                path: ''
-              }, {
-                name: 'Spaces',
-                path: '_spaces'
-              }, {
-                name: 'Resources',
-                path: '_resources'
-              }
-            ]
-          }
-        ]
-      ],
-      [
         ContextTypes.BUILTIN.get('space'),
         [
           {


### PR DESCRIPTION
Removed settings, home, and profile from the home page.
Reviewed with Catherine -- no highlighting of context menu.

![screen shot 2017-04-20 at 2 21 38 pm](https://cloud.githubusercontent.com/assets/17481322/25246138/b77cc1ae-25d4-11e7-8c90-f06c692c67eb.png)
