### PR TITLE
fix(wizard): fix validation

### DIFF
--- a/src/app/space-wizard/services/concrete/app-generator-configuration.service.ts
+++ b/src/app/space-wizard/services/concrete/app-generator-configuration.service.ts
@@ -71,6 +71,10 @@ export class AppGeneratorConfigurationService {
         appGeneratorResponse.payload.state.title = 'GitHub repository information';
         break;
       }
+      case 'fabric8: new project': {
+        appGeneratorResponse.payload.state.title = 'Quickstart';
+        break;
+      }
       case 'launchpad: new project': {
         appGeneratorResponse.payload.state.title = 'Quickstart';
         break;

--- a/src/app/space-wizard/services/concrete/fabric8-forge.service.ts
+++ b/src/app/space-wizard/services/concrete/fabric8-forge.service.ts
@@ -53,7 +53,8 @@ export class Fabric8ForgeService extends ForgeService {
         return this.forgeHttpCommandRequest(request);
       }
       case ForgeCommands.forgeQuickStart: {
-        command.parameters.pipeline.name = 'launchpad-new-project';
+        //command.parameters.pipeline.name = 'launchpad-new-project';
+        command.parameters.pipeline.name = 'fabric8-new-project';
         // here are the fabric8 upstream quickstarts:
         //command.parameters.pipeline.name = 'fabric8-new-quickstart';
         return this.forgeHttpCommandRequest(request);


### PR DESCRIPTION
switch to the new fabric8-new-project command which adds validation on the first page for the git repo name