### PR TITLE
feat(home): Added developer poll component

### DIFF
--- a/src/app/home/developer-poll/developer-poll-routing.module.ts
+++ b/src/app/home/developer-poll/developer-poll-routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule }  from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { DeveloperPollComponent } from './developer-poll.component';
+
+const routes: Routes = [{
+  path: '',
+  component: DeveloperPollComponent
+}];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class DeveloperPollRoutingModule {}

--- a/src/app/home/developer-poll/developer-poll.component.html
+++ b/src/app/home/developer-poll/developer-poll.component.html
@@ -25,6 +25,6 @@
               [disabled]="voted"
               (click)="vote($event)">13+</button>
     </div>
-    <p class="padding-top-10">{{votes}} votes</p>
+    <p class="padding-top-10">{{ votes | number : fractionSize}} votes</p>
   </div>
 </div>

--- a/src/app/home/developer-poll/developer-poll.component.html
+++ b/src/app/home/developer-poll/developer-poll.component.html
@@ -1,0 +1,30 @@
+<div class="card-pf card-f8">
+  <div class="card-pf-heading">
+    <h2 class="card-pf-title">Developer poll</h2>
+  </div>
+  <div class="card-pf-body card-f8-body text-center">
+    <h3 class="margin-top-none">How many people are in your development team?</h3>
+    <p>i.e. Your sprint team</p>
+    <div class="margin-top-15">
+      <button type="submit" class="btn btn-lg btn-default width-100"
+              [disabled]="voted"
+              (click)="vote($event)">1-2</button>
+    </div>
+    <div class="margin-top-15">
+      <button type="submit" class="btn btn-lg btn-default width-100"
+              [disabled]="voted"
+              (click)="vote($event)">3-7</button>
+    </div>
+    <div class="margin-top-15">
+      <button type="submit" class="btn btn-lg btn-default width-100"
+              [disabled]="voted"
+              (click)="vote($event)">9-12</button>
+    </div>
+    <div class="margin-top-15 margin-bottom-15">
+      <button type="submit" class="btn btn-lg btn-default width-100"
+              [disabled]="voted"
+              (click)="vote($event)">13+</button>
+    </div>
+    <p class="padding-top-10">{{votes}} votes</p>
+  </div>
+</div>

--- a/src/app/home/developer-poll/developer-poll.component.scss
+++ b/src/app/home/developer-poll/developer-poll.component.scss
@@ -1,0 +1,7 @@
+@import '../../../assets/stylesheets/base';
+@import '../../../assets/stylesheets/shared/layout';
+
+.btn-lg {
+  padding-bottom: 12px;
+  padding-top: 12px;
+}

--- a/src/app/home/developer-poll/developer-poll.component.ts
+++ b/src/app/home/developer-poll/developer-poll.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  encapsulation: ViewEncapsulation.None,
+  selector: 'alm-developer-poll',
+  templateUrl: './developer-poll.component.html',
+  styleUrls: ['./developer-poll.component.scss'],
+})
+export class DeveloperPollComponent implements OnInit {
+  voted: boolean = false;
+  votes: number = 2304;
+
+  constructor(private router: Router) {
+  }
+
+  ngOnInit(): void {
+  }
+
+  vote($event: MouseEvent): void {
+    this.votes++;
+    this.voted = true;
+  }
+}

--- a/src/app/home/developer-poll/developer-poll.module.ts
+++ b/src/app/home/developer-poll/developer-poll.module.ts
@@ -1,0 +1,17 @@
+import { RouterModule } from '@angular/router';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { DeveloperPollComponent } from './developer-poll.component';
+import { DeveloperPollRoutingModule } from './developer-poll-routing.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    DeveloperPollRoutingModule,
+    RouterModule
+  ],
+  declarations: [DeveloperPollComponent],
+  exports: [DeveloperPollComponent],
+})
+export class DeveloperPollModule { }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -168,20 +168,7 @@
         </div>
       </div>
       <div class="col-md-4">
-        <div class="card-pf card-f8">
-          <div class="card-pf-heading">
-            <h2 class="card-pf-title">Resource usage</h2>
-          </div>
-          <div class="card-pf-body card-f8-body">
-            <div class="blank-slate-f8-card">
-              <div class="blank-slate-f8-icon">
-                <span class="pficon pficon-info"></span>
-              </div>
-              <h3>No Resource are currently in use</h3>
-              <p>Add memory, CPU, or storage resources by <a href="#">creating a space</a> or <a href="#">updating content.</a></p>
-            </div>
-          </div>
-        </div>
+        <alm-developer-poll></alm-developer-poll>
       </div>
     </div>
   </div>

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -8,9 +8,16 @@ import { SpaceWizardModule } from '../space-wizard/space-wizard.module';
 
 import { HomeComponent }   from './home.component';
 import { HomeRoutingModule }   from './home-routing.module';
+import { DeveloperPollModule } from './developer-poll/developer-poll.module';
 
 @NgModule({
-  imports:      [ CommonModule, HomeRoutingModule, ModalModule, SpaceWizardModule, Fabric8WitModule ],
+  imports: [
+    CommonModule,
+    DeveloperPollModule,
+    HomeRoutingModule,
+    ModalModule,
+    SpaceWizardModule,
+    Fabric8WitModule ],
   declarations: [ HomeComponent ]
 })
 export class HomeModule {


### PR DESCRIPTION
This is a temporary placeholder to help fill in the home page for summit and not intended to be a fully functional poll.

In order to match the mockup provided by @catrobson , the buttons are intentionally taller in height than the "large" type Patternfly buttons.

Before a button has been selected
![screen shot 2017-04-21 at 10 45 41 pm](https://cloud.githubusercontent.com/assets/17481322/25300809/dc073d62-26e5-11e7-83e5-3cdf2eba895e.png)

After any button has been selected:
![screen shot 2017-04-21 at 10 46 00 pm](https://cloud.githubusercontent.com/assets/17481322/25300803/ccf276c0-26e5-11e7-9063-6167f815a825.png)

