### PR TITLE
fix(stack_report_link): introduce the stack report link as per ux discussion that opens a bayesian modal on click

### DIFF
--- a/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.html
+++ b/src/app/dashboard-widgets/analytical-report-widget/analytical-report-widget.component.html
@@ -1,7 +1,8 @@
 <div class="analytical-report-widget card-pf card-f8 card-pf-utilization">
   <div class="card-pf-heading">
     <h2 class="card-pf-title">
-      Stack Reports
+      <span *ngIf="!currentBuild || !currentBuild.annotations || !currentBuild.annotations['fabric8.io/bayesian.analysisUrl']">Stack Reports</span>
+      <stack-details [stack]="currentBuild && currentBuild.annotations && currentBuild.annotations['fabric8.io/bayesian.analysisUrl']" *ngIf="currentBuild && currentBuild.annotations && currentBuild.annotations['fabric8.io/bayesian.analysisUrl']"></stack-details>
     </h2>
   </div>
   <div class="card-pf-body card-f8-body analytical-report-body">


### PR DESCRIPTION
Changes:

2 scenarios

1. 'Stack Report' text becomes a link when there is sufficient bayesian information to show from the build that is selected.
2. 'Stack Report' text appears black (without link) WHEN,
	a. There is no bayesian information to be shown from the build that is selected,
	b. There are no pipelines,
	c. There is no pipeline selected,
	d. There is no build selected

