### PR TITLE
fix(): Set registrationCompleted if username is saved

### DIFF
--- a/src/app/getting-started/getting-started.component.ts
+++ b/src/app/getting-started/getting-started.component.ts
@@ -208,8 +208,8 @@ export class GettingStartedComponent implements OnDestroy, OnInit {
     return (this.username !== undefined
       && this.username.trim().length !== 0
       && this.username.trim().length < 63
-      && this.username.trim().indexOf("-") === -1
-      && this.username.trim().indexOf("_") === -1);
+      && this.username.trim().indexOf("-") !== 0
+      && this.username.trim().indexOf("_") !== 0);
   }
 
   /**


### PR DESCRIPTION
- Set registration_completed=true if username is saved successfully.
- Added check to prevent subscription from routing to home again prior to onDestroy.
- Ensured registration_complete and tokens are all obtained before checking if we route to home.

Note: I'm not able to test a username change, but believe setting registration_completed=true will cover that.

Unfortunately, a user only gets to update once. When Aslak resets my registrtation_complete property in our db, I'll retest.

