### PR TITLE
fix(truncation): fix truncation for cards on smaller screen

### DIFF
--- a/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.scss
+++ b/src/app/dashboard-widgets/add-codebase-widget/add-codebase-widget.component.scss
@@ -9,6 +9,9 @@
   position: absolute;
   left: 50px;
   width: 475px;
+  @media (max-width: 1281px) {
+    width: 83%;
+  }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.scss
+++ b/src/app/dashboard-widgets/create-work-item-widget/create-work-item-widget.component.scss
@@ -17,6 +17,9 @@
   position: absolute;
   left: 115px;
   width: 420px;
+  @media (max-width: 1281px) {
+    width: 64%;
+  }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/app/home/work-item-widget/work-item-widget.component.scss
+++ b/src/app/home/work-item-widget/work-item-widget.component.scss
@@ -10,6 +10,9 @@
 }
 .combobox {
   width: 330px;
+  @media (max-width: 1281px) {
+    width: 50%;
+  }
   position: absolute;
   top: 15px;
   right: 25px;
@@ -18,6 +21,9 @@
   position: absolute;
   left: 115px;
   width: 425px;
+  @media (max-width: 1281px) {
+    width: 65%;
+  }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
fix the truncation on the list items inside of cards on the dashboards for demo screens

NOTE: This is so the list items inside of the Dashboard cards truncate at 1280px wide screens, without running outside of the cards.
