### PR TITLE
fix(codebases): Headers must be on own list view row

### DIFF
--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.html
@@ -1,15 +1,22 @@
-<span class="dropdown-kebab-pf" dropdown>
-  <button class="btn btn-link" type="button" dropdownToggle>
-    <span class="fa fa-ellipsis-v"></span>
-  </button>
-  <ul class="dropdown-menu-right" aria-labelledby="dropdownKebab" dropdownMenu>
-    <li>
-      <a href="javascript:void(0)" class="secondary-action"
-         (click)="createAndOpenWorkspace()">Create workspace</a>
-    </li>
-    <li class="disabled">
-      <a href="javascript:void(0)" class="secondary-action"
-         (click)="deleteCodebase()" disabled>Remove codebase</a>
-    </li>
-  </ul>
-</span>
+<div *ngIf="index === 0; then showHeader else showCol"></div>
+<ng-template #showHeader>
+  <!-- Extra margin for kebab -->
+  <span class="margin-right-20"></span>
+</ng-template>
+<ng-template #showCol>
+  <span class="dropdown-kebab-pf" dropdown>
+    <button class="btn btn-link" type="button" dropdownToggle>
+      <span class="fa fa-ellipsis-v"></span>
+    </button>
+    <ul class="dropdown-menu-right" aria-labelledby="dropdownKebab" dropdownMenu>
+      <li>
+        <a href="javascript:void(0)" class="secondary-action"
+           (click)="createAndOpenWorkspace()">Create workspace</a>
+      </li>
+      <li class="disabled">
+        <a href="javascript:void(0)" class="secondary-action"
+           (click)="deleteCodebase()" disabled>Remove codebase</a>
+      </li>
+    </ul>
+  </span>
+</ng-template>

--- a/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.scss
+++ b/src/app/create/codebases/codebases-item-actions/codebases-item-actions.component.scss
@@ -1,2 +1,9 @@
 @import '../../../../assets/stylesheets/base';
-codebases-item-actions { display: flex; }
+
+codebases-item-actions {
+  display: flex;
+}
+
+.margin-right-20 {
+  margin-right: 20px;
+}

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.html
@@ -1,7 +1,3 @@
-<span class="list-group-heading workspace-info" *ngIf="index === 0">CHE WORKSPACES
-  <i class="pficon pficon-info"
-     tooltip="Che workspaces are web based development environments for to your code and runtime needs"></i>
-</span>
 <div *ngIf="workspacesAvailable; then showOpenWorkspace else showCreateWorkspace"></div>
 <ng-template #showOpenWorkspace>
   <select class="combobox form-control workspace-select"
@@ -19,7 +15,7 @@
 </ng-template>
 <ng-template #showCreateWorkspace>
   <a href="javascript:void(0)" (click)="createAndOpenWorkspace()">
-    <i class="pficon pficon-add-circle-o margin-right-5"></i>Create workspace</a>
+    <i class="pficon pficon-add-circle-o margin-right-10"></i>Create workspace</a>
 </ng-template>
 <div class="busy-indicator" *ngIf="workspaceBusy">
   <div class="spinner spinner-sm"></div>

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.scss
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.scss
@@ -3,10 +3,10 @@
 codebases-item-workspaces { display: flex; }
 
 .busy-indicator {
+  position: relative;
   display: flex;
   height: auto;
   margin-left: 10px;
-  position: relative;
   vertical-align: center;
   width: 25px;
   > div {

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.scss
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.scss
@@ -1,22 +1,22 @@
 @import '../../../../assets/stylesheets/base';
-codebases-item-workspaces { display: flex; }
+
+codebases-item-workspaces {
+  display: flex;
+}
+
 .busy-indicator {
-  position: relative;
   display: flex;
   height: auto;
-  width: 25px;
   margin-left: 10px;
+  position: relative;
   vertical-align: center;
+  width: 25px;
   > div {
-    margin: auto;
-    padding: 0;
+    margin:auto;
+    padding:0;
   }
 }
-.workspace-info {
-  margin-right: 5px;
-  min-width: 250px;
-  i { pointer-events: auto; }
-}
+
 .workspace-select {
   height: 32px;
   margin-right: 5px;

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.scss
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.component.scss
@@ -1,8 +1,6 @@
 @import '../../../../assets/stylesheets/base';
 
-codebases-item-workspaces {
-  display: flex;
-}
+codebases-item-workspaces { display: flex; }
 
 .busy-indicator {
   display: flex;
@@ -12,8 +10,8 @@ codebases-item-workspaces {
   vertical-align: center;
   width: 25px;
   > div {
-    margin:auto;
-    padding:0;
+    margin: auto;
+    padding: 0;
   }
 }
 

--- a/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.module.ts
+++ b/src/app/create/codebases/codebases-item-workspaces/codebases-item-workspaces.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DropdownModule, TooltipModule } from 'ng2-bootstrap';
+import { DropdownModule } from 'ng2-bootstrap';
 import { FormsModule } from '@angular/forms';
 import { Http } from '@angular/http';
 import { WindowService } from '../services/window.service';
@@ -11,8 +11,7 @@ import { CodebasesItemWorkspacesComponent } from './codebases-item-workspaces.co
   imports: [
     CommonModule,
     DropdownModule,
-    FormsModule,
-    TooltipModule
+    FormsModule
   ],
   declarations: [ CodebasesItemWorkspacesComponent ],
   exports: [ CodebasesItemWorkspacesComponent ],

--- a/src/app/create/codebases/codebases-item/codebases-item.component.html
+++ b/src/app/create/codebases/codebases-item/codebases-item.component.html
@@ -1,31 +1,47 @@
-<div class="list-view-pf-left">
-  <span class="fa list-view-pf-icon-sm" [ngClass]="{'fa-github': codebase.attributes.type === 'git'}"></span>
-</div>
-<div class="list-view-pf-body">
-  <div class="list-view-pf-description">
-    <div class="list-group-item-heading">
-      <span class="list-group-heading" *ngIf="index === 0">NAME</span>
-      <a [href]="htmlUrl" target="_blank" *ngIf="!isHtmlUrlInvalid()">{{fullName}}</a>
-      <span *ngIf="isHtmlUrlInvalid()">Invalid URL</span>
+<div *ngIf="index === 0; then showHeader else showCol"></div>
+<ng-template #showHeader>
+  <div class="list-view-pf-left">
+    <!-- Extra margin for icon -->
+    <div class="margin-right-30"></div>
+  </div>
+  <div class="list-view-pf-body">
+    <div class="list-view-pf-description">
+      <div class="list-group-item-heading">
+        <span class="list-group-heading">NAME</span>
+      </div>
+      <div class="list-group-item-text">
+        <span class="list-group-heading">CREATED DATE</span>
+      </div>
     </div>
     <div class="list-group-item-text">
-      <span class="list-group-heading" *ngIf="index === 0">CREATED DATE</span>
-      {{createdDate | date:'medium'}}
+      <span class="list-group-heading">LAST COMMIT</span>
+    </div>
+    <div class="list-group-item-text">
+      <span class="list-group-heading">CHE WORKSPACES
+        <i class="pficon pficon-info margin-left-5"
+           tooltip="Che workspaces are web based development environments for your code and runtime needs"></i>
+      </span>
     </div>
   </div>
-  <div class="list-group-item-text">
-    <span class="list-group-heading" *ngIf="index === 0">LAST COMMIT</span>
-    {{lastCommitDate | date:'medium'}}
+</ng-template>
+<ng-template #showCol>
+  <div class="list-view-pf-left">
+    <span class="fa list-view-pf-icon-sm" [ngClass]="{'fa-github': codebase?.attributes?.type === 'git'}"></span>
   </div>
-  <div class="list-group-item-text">
-    <codebases-item-workspaces [codebase]="codebase" [index]="index"></codebases-item-workspaces>
-  </div>
-
-  <!--
-  <div class="list-view-pf-additional-info">
-    <div class="list-view-pf-additional-info-item">
+  <div class="list-view-pf-body">
+    <div class="list-view-pf-description">
+      <div class="list-group-item-heading">
+        <a [href]="htmlUrl" target="_blank">{{fullName}}</a>
+      </div>
+      <div class="list-group-item-text">
+        {{createdDate | date:'medium'}}
+      </div>
+    </div>
+    <div class="list-group-item-text">
       {{lastCommitDate | date:'medium'}}
     </div>
+    <div class="list-group-item-text">
+      <codebases-item-workspaces [codebase]="codebase" [index]="index"></codebases-item-workspaces>
+    </div>
   </div>
-  -->
-</div>
+</ng-template>

--- a/src/app/create/codebases/codebases-item/codebases-item.component.scss
+++ b/src/app/create/codebases/codebases-item/codebases-item.component.scss
@@ -1,12 +1,14 @@
 /* Margin for group heading */
-.list-view-pf-view { margin-top: 75px; }
-.list-view-pf {
-  .list-group-item-heading {
-    flex-basis: calc(25% - 20px);
-    width: calc(25% - 20px);
-  }
-  .list-group-item-text {
-    flex-basis: calc(25% - 40px);
-    width: calc(25% - 40px);
-  }
+.list-view-pf .list-group-item-heading {
+  flex-basis: calc(25% - 20px);
+  width: calc(25% - 20px);
+}
+
+.list-view-pf .list-group-item-text {
+  flex-basis: calc(25% - 40px);
+  width: calc(25% - 40px);
+}
+
+.margin-right-30 {
+  margin-right: 30px;
 }

--- a/src/app/create/codebases/codebases-item/codebases-item.component.spec.ts
+++ b/src/app/create/codebases/codebases-item/codebases-item.component.spec.ts
@@ -83,24 +83,4 @@ describe('Codebases Item Component', () => {
       expect(spanDisplayedInformation.length).toEqual(3)
     });
   }));
-
-  it('Init component in error', async(() => {
-    // given
-    let comp = fixture.componentInstance;
-    let debug = fixture.debugElement;
-    comp.codebase = cloneDeep(codebase);
-    comp.codebase.attributes.url = 'bo:o';
-    const errorNotif = {
-      message: "An Error",
-      type: NotificationType.DANGER
-    };
-    notificationMock.message.and.returnValue(Observable.of(errorNotif));
-    fixture.detectChanges();
-    let spanParent = debug.query(By.css('.list-group-item-heading'));
-    let spanError = spanParent.query(By.css('span:last-child'));
-    fixture.whenStable().then(() => {
-      expect(spanError.nativeElement.textContent).toEqual("Invalid URL");
-      expect(notificationMock.message).toHaveBeenCalled();
-    });
-  }));
 });

--- a/src/app/create/codebases/codebases-item/codebases-item.component.ts
+++ b/src/app/create/codebases/codebases-item/codebases-item.component.ts
@@ -34,7 +34,7 @@ export class CodebasesItemComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit(): void {
-    if (this.codebase === undefined) {
+    if (this.codebase === undefined || this.codebase.attributes === undefined) {
       return;
     }
     if (this.codebase.attributes.type === 'git') {

--- a/src/app/create/codebases/codebases-item/codebases-item.module.ts
+++ b/src/app/create/codebases/codebases-item/codebases-item.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { TooltipModule } from 'ng2-bootstrap';
 import { Http } from '@angular/http';
 import { CodebasesService } from '../services/codebases.service';
 import { GitHubService } from "../services/github.service";
@@ -11,7 +12,8 @@ import { CodebasesItemWorkspacesModule } from '../codebases-item-workspaces/code
   imports: [
     CodebasesItemWorkspacesModule,
     CommonModule,
-    FormsModule
+    FormsModule,
+    TooltipModule
   ],
   declarations: [ CodebasesItemComponent ],
   exports: [ CodebasesItemComponent ],

--- a/src/app/create/codebases/codebases.component.ts
+++ b/src/app/create/codebases/codebases.component.ts
@@ -9,6 +9,8 @@ import { Context, Contexts } from 'ngx-fabric8-wit';
 import { GitHubService } from "./services/github.service";
 import { Broadcaster, Notification, NotificationType, Notifications } from 'ngx-base';
 
+import { cloneDeep } from 'lodash';
+
 import {
   EmptyStateConfig,
   Filter,
@@ -83,6 +85,7 @@ export class CodebasesComponent implements OnDestroy, OnInit {
       dblClick: false,
       dragEnabled: false,
       emptyStateConfig: this.emptyStateConfig,
+      headingRow: true,
       multiSelect: false,
       selectItems: false,
       //selectionMatchProp: 'name',
@@ -109,9 +112,10 @@ export class CodebasesComponent implements OnDestroy, OnInit {
         }
       });
     } else {
-      this.codebases = this.allCodebases;
+      this.codebases = cloneDeep(this.allCodebases);
     }
     this.resultsCount = this.codebases.length;
+    this.codebases.unshift({} as Codebase); // Add empty object for row header
   }
 
   filterChange($event: FilterEvent): void {
@@ -194,7 +198,8 @@ export class CodebasesComponent implements OnDestroy, OnInit {
       .subscribe(codebases => {
         if (codebases != null) {
           this.allCodebases = codebases;
-          this.codebases = this.allCodebases;
+          this.codebases = cloneDeep(codebases);
+          this.codebases.unshift({} as Codebase); // Add empty object for row header
         }
       }, error => {
         this.handleError("Failed to retrieve codebases", NotificationType.DANGER);


### PR DESCRIPTION
Refactored list view to place column headers on their own row. 

An issue was discovered after adding an info icon to the list view header on the codebases page. When the user hovers over the icon, a tooltip is displayed, but the first row is also unexpectedly highlighted. Moving headers to their own row ensures mouseover/mouseenter events are not fired for the first list view row.

Note: This PR will depend on ngx-widgets:
https://github.com/fabric8-ui/ngx-widgets/pull/76

<img width="1438" alt="screen shot 2017-04-28 at 2 25 54 am" src="https://cloud.githubusercontent.com/assets/17481322/25517100/d862d2e0-2bbb-11e7-8e63-ed1fb4d39e23.png">
