### PR TITLE
fix(AuthenticationService): Listen for noFederatedToken

### DIFF
--- a/src/app/shared/login.service.ts
+++ b/src/app/shared/login.service.ts
@@ -43,6 +43,12 @@ export class LoginService {
     this.broadcaster.on('authenticationError').subscribe(() => {
       this.authService.logout();
     });
+    this.broadcaster.on('noFederatedToken').subscribe(() => {
+      // Don't log out first time users from getting started as tokens may not exist
+      if (this.router.url !== "/" && this.router.url.indexOf("_gettingstarted") === -1) {
+        this.authService.logout();
+      }
+    });
   }
 
   redirectToAuth() {


### PR DESCRIPTION
Listen for noFederatedToken instead of authenticationError.
Fixes issue: https://github.com/fabric8-ui/ngx-login-client/issues/55

