### PR TITLE
fix(): Save username automatically

### DIFF
--- a/src/app/getting-started/getting-started.component.html
+++ b/src/app/getting-started/getting-started.component.html
@@ -15,6 +15,7 @@
     </div>
   </div>
   <div class="row">
+<!--
     <form role="form">
       <div class="row">
         <div class="col-md-1">
@@ -39,9 +40,7 @@
               <label for="username" class="control-label required-pf">Username</label>
               <div [ngClass]="{'has-error': usernameInvalid}">
                 <div class="col-md-5 padding-left-0">
-                  <!-- Disable username change for summit, but require save to set registration_complete -->
                   <input type="text" class="form-control" id="username" name="username" maxlength="62" required
-                         [disabled]="true"
                          [(ngModel)]="username">
                 </div>
                 <div class="col-md-7 padding-left-0">
@@ -60,6 +59,7 @@
           </div>
         </div>
       </div>
+-->
       <div class="row">
         <div class="col-md-1">
           <h2 class="circle">2</h2>

--- a/src/app/getting-started/getting-started.component.ts
+++ b/src/app/getting-started/getting-started.component.ts
@@ -55,6 +55,11 @@ export class GettingStartedComponent implements OnDestroy, OnInit {
         this.loggedInUser = user;
         this.username = this.loggedInUser.attributes.username;
         this.registrationCompleted = (user as ExtUser).attributes.registrationCompleted;
+
+        // Todo: Remove after summit?
+        if (!this.registrationCompleted) {
+          this.saveUsername();
+        }
       })
       .switchMap(() => this.auth.gitHubToken)
       .map(token => {


### PR DESCRIPTION
This will save the username automatically when the user visits the getting started page. However, users may jump right to the home page if their tokens are already linked (e.g., via Keycloak).