### PR TITLE
fix(getting-started): Fix broken form tag

### DIFF
--- a/src/app/getting-started/getting-started.component.html
+++ b/src/app/getting-started/getting-started.component.html
@@ -15,8 +15,8 @@
     </div>
   </div>
   <div class="row">
-<!--
     <form role="form">
+<!--
       <div class="row">
         <div class="col-md-1">
           <h2 class="circle">1</h2>


### PR DESCRIPTION
Due to recent edits, the form tag is not closed properly. The resulting errors in the page prevent login.

