### PR TITLE
Propagate end-to-end username and password credentials inside container

### DIFF
--- a/cico_run_EE_tests.sh
+++ b/cico_run_EE_tests.sh
@@ -29,9 +29,9 @@ service docker start
 cp /tmp/jenkins-env .
 docker build -t fabric8-ui-builder -f Dockerfile.builder .
 # User root is required to run webdriver-manager update. This shouldn't be a problem for CI containers
-mkdir -p dist && docker run --detach=true --name=fabric8-ui-builder --user=root --cap-add=SYS_ADMIN -e "API_URL=http://api.prod-preview.openshift.io/api/" -e "CI=true" -t -v $(pwd)/dist:/dist:Z fabric8-ui-builder
+mkdir -p dist && docker run --detach=true --name=fabric8-ui-builder --user=root --cap-add=SYS_ADMIN -e EE_TEST_USERNAME=$EE_TEST_USERNAME -e EE_TEST_PASSWORD=$EE_TEST_PASSWORD -e "API_URL=http://api.prod-preview.openshift.io/api/" -e "CI=true" -t -v $(pwd)/dist:/dist:Z fabric8-ui-builder
 
-# Build 
+# Build
 docker exec fabric8-ui-builder npm install
 
 ## Clean up OpenShift builds, pipelines, etc. from prior jobs - commented out for now - until test can run more reliably
@@ -62,4 +62,3 @@ docker exec fabric8-ui-builder ./run_EE_tests.sh $1
 # Test results to archive
 docker cp fabric8-ui-builder:/home/fabric8/fabric8-ui/target/ .
 docker cp fabric8-ui-builder:/home/fabric8/fabric8-ui/functional_tests.log target
-


### PR DESCRIPTION
…ker container

The credentials are used in the script `run_EE_tests.sh`. Nut they aren't propagated from the jenkins slave where they are defined



