### PR TITLE
fix(webpack): allow webpack-dev-server to serve dot url

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -242,7 +242,9 @@ module.exports = function (options) {
     devServer: {
       port: METADATA.port,
       host: METADATA.host,
-      historyApiFallback: true,
+      historyApiFallback: {
+        disableDotRule: true,
+      },
       watchOptions: {
         aggregateTimeout: 2000
       },


### PR DESCRIPTION
Fixes https://github.com/fabric8io/fabric8-ui/issues/1390