### PR TITLE
fix(profile): Spell "tenent" properly as "tenant"

### DIFF
--- a/src/app/profile/update/update.component.html
+++ b/src/app/profile/update/update.component.html
@@ -249,7 +249,7 @@
           </div>
           <div class="form-group">
             <button class="btn btn-lg btn-default"
-                    (click)="updateTenent()">Update tenent</button>
+                    (click)="updateTenent()">Update tenant</button>
           </div>
         </div>
       </form>


### PR DESCRIPTION
Fixes #1256

