### PR TITLE
fix(navbar): fix pipeline history nav bar

### DIFF
--- a/environments/openshift-prod-cluster.sh
+++ b/environments/openshift-prod-cluster.sh
@@ -30,17 +30,13 @@ fi
 if [ -z "${OAUTH_CLIENT_ID}" ]; then
   export OAUTH_CLIENT_ID="fabric8"
 fi
-if [ -z "${K8S_API_SERVER_PROTOCOL}" ]; then
-  export K8S_API_SERVER_PROTOCOL="http"
-fi
-if [ -z "${K8S_API_SERVER_BASE_PATH}" ]; then
-  export K8S_API_SERVER_BASE_PATH="/_p/oso"
-fi
 if [ -z "${FABRIC8_PIPELINES_NAMESPACE}" ]; then
   export FABRIC8_PIPELINES_NAMESPACE=""
 fi
 
 
+export K8S_API_SERVER_BASE_PATH=""
+export K8S_API_SERVER_PROTOCOL="https"
 export OAUTH_ISSUER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
 export WS_K8S_API_SERVER="${PROXIED_K8S_API_SERVER}"
 


### PR DESCRIPTION
selection should check for sub path matches if no direct match found and
    use reverse order to avoid matching 'Codebases' first (or the first tab in
    general when a more specific URL matches) fixes
    https://github.com/fabric8io/fabric8-ui/issues/870