### PR TITLE
fix(codebases): fix text of Column and Tooltip

### DIFF
--- a/src/app/create/codebases/codebases-item/codebases-item.component.html
+++ b/src/app/create/codebases/codebases-item/codebases-item.component.html
@@ -17,9 +17,10 @@
       <span class="list-group-heading">LAST COMMIT</span>
     </div>
     <div class="list-group-item-text">
-      <span class="list-group-heading">CHE WORKSPACES
+      <span class="list-group-heading">WORKSPACES
         <i class="pficon pficon-info margin-left-5"
-           tooltip="Che workspaces are web based development environments for your code and runtime needs"></i>
+           tooltip="Workspaces are web based development environments for your code and runtime needs"
+           placement="top"></i>
       </span>
     </div>
   </div>


### PR DESCRIPTION
update the text to read 'Workspaces' rather than 'Che Workspaces'

fixes #1221

